### PR TITLE
feat!: Switch to click CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 authors = [{ name = "Trevor Manz", email = "trevor.j.manz@gmail.com" }]
 requires-python = ">=3.10"
 dependencies = [
+    "click>=8.1.7",
     "jupytext>=1.16.4",
     "rich>=13.9.2",
 ]

--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -242,7 +242,9 @@ def version() -> None:
 @cli.command()
 def info():
     """Display juv and uv versions."""
-    version()
+    import importlib.metadata
+
+    print(f"juv {importlib.metadata.version('juv')}")
     uv_version = subprocess.run(["uv", "version"], capture_output=True, text=True)
     print(uv_version.stdout)
 
@@ -290,7 +292,6 @@ def add(file: str, requirements: str | None, packages: tuple[str, ...]) -> None:
 @click.option(
     "--notebook",
     "-n",
-    type=click.STRING,
     required=False,
     help="The notebook runner the run environment. [env: JUV_NOTEBOOK=]",
 )
@@ -305,7 +306,6 @@ def run(
     """Launch a notebook or script."""
     runtime = parse_notebook_specifier(notebook)
     path = Path(file)
-
     meta, nb = to_notebook(path)
 
     if path.suffix == ".py":
@@ -317,7 +317,9 @@ def run(
 
     meta = Pep723Meta.from_toml(meta) if meta else None
 
-    uv_flags = list(with_args)
+    uv_flags = []
+    for arg in with_args:
+        uv_flags.extend(["--with", arg])
     if python:
         uv_flags.extend(["--python", python])
 

--- a/tests/test_juv.py
+++ b/tests/test_juv.py
@@ -195,7 +195,7 @@ def test_run_nbclassic() -> None:
 
 def test_run_notebook() -> None:
     assert juv.create_uv_run_command(
-        command=juv.Notebook(file=Path("test.ipynb"), version="6.4.0"),
+        command=juv.Runtime(file=Path("test.ipynb"), version="6.4.0"),
         pep723_meta=Pep723Meta(dependencies=[], requires_python=None),
         pre_args=[],
     ) == snapshot(

--- a/uv.lock
+++ b/uv.lock
@@ -191,6 +191,7 @@ name = "juv"
 version = "0.1.5"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "jupytext" },
     { name = "rich" },
 ]
@@ -204,6 +205,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.1.7" },
     { name = "jupytext", specifier = ">=1.16.4" },
     { name = "rich", specifier = ">=13.9.2" },
 ]


### PR DESCRIPTION
Migrates CLI parsing to use `click`.

This PR also deprecates the use of top-level `lab`, `notebook`, `nbclassic`
commands and making the parsing of uv's flags more consistent.

Instead, for consistency with `uv`, we prefer `run` with the `--jupyter` flag
to specify a notebook runtime. Users can set their preferences with a
`JUV_JUPYTER` environment variable.

This way juv's CLI is more similar to uv, so learning should be similar. This will

```uv
uv init --script foo.py
uv add --script foo.py anywidget
uv run foo.py
```

```sh
# basic
juv init
juv add Untitled.ipynb anywidget
juv run Untitled.ipynb
# JUV_JUPYTER=notebook@6 juv run Untitled.ipynb

# more advanced
juv run --jupyter=nbclassic --python=3.4 --with=polars Untitled.ipynb
```