### PR TITLE
feat: Add managed run mode via `JUV_RUN_MODE=managed` env

### DIFF
--- a/src/juv/_run.py
+++ b/src/juv/_run.py
@@ -147,7 +147,7 @@ def run(
     if os.environ.get("JUV_RUN_MODE") == "managed":
         from ._run_managed import run as run_managed
 
-        run_managed(args, path.name, runtime.name)
+        run_managed(args, path.name, runtime.name, runtime.version)
     else:
         from uv import find_uv_bin
 

--- a/src/juv/_run.py
+++ b/src/juv/_run.py
@@ -12,7 +12,6 @@ import jupytext
 
 from ._nbconvert import write_ipynb, code_cell
 from ._pep723 import parse_inline_script_metadata, extract_inline_meta
-from uv import find_uv_bin
 
 
 @dataclass
@@ -127,6 +126,7 @@ def run(
     with_args: typing.Sequence[str],
 ) -> None:
     """Launch a notebook or script."""
+    runtime = parse_notebook_specifier(jupyter)
     meta, nb = to_notebook(path)
 
     if path.suffix == ".py":
@@ -136,16 +136,24 @@ def run(
             f"Converted script to notebook `[cyan]{path.resolve().absolute()}[/cyan]`"
         )
 
-    uv = os.fsdecode(find_uv_bin())
     args = prepare_uv_tool_run_args(
         target=path,
-        runtime=parse_notebook_specifier(jupyter),
+        runtime=runtime,
         meta=Pep723Meta.from_toml(meta) if meta else Pep723Meta([], None),
         python=python,
         extra_with_args=with_args,
     )
-    try:
-        os.execvp(uv, args)
-    except OSError as e:
-        rich.print(f"Error executing [cyan]uvx[/cyan]: {e}", file=sys.stderr)
-        sys.exit(1)
+
+    if os.environ.get("JUV_RUN_MODE") == "managed":
+        from ._run_managed import run as run_managed
+
+        run_managed(args, path.name, runtime.name)
+    else:
+        from uv import find_uv_bin
+
+        uv = os.fsdecode(find_uv_bin())
+        try:
+            os.execvp(uv, args)
+        except OSError as e:
+            rich.print(f"Error executing [cyan]uvx[/cyan]: {e}", file=sys.stderr)
+            sys.exit(1)

--- a/src/juv/_run_managed.py
+++ b/src/juv/_run_managed.py
@@ -111,11 +111,17 @@ def run(
     )
     output_thread.start()
 
+    status = console.status("Starting Jupyter Server", spinner="dots")
+    status.start()
+
     try:
         while True and process.stdout:
             line = process.stdout.readline()
             if not line and process.poll() is not None:
                 break
+            if line and status:
+                status.stop()
+                status = None
             output_queue.put(line)
     except KeyboardInterrupt:
         with console.status("Shutting down..."):

--- a/src/juv/_run_managed.py
+++ b/src/juv/_run_managed.py
@@ -20,12 +20,14 @@ from ._version import __version__
 from rich.console import Console
 
 
-def get_version(jupyter: str):
+def get_version(jupyter: str, version: str | None):
     with_jupyter = {
         "lab": "--with=jupyterlab",
         "notebook": "--with=notebook",
         "nbclassic": "--with=nbclassic",
     }[jupyter]
+    if version:
+        with_jupyter += f"=={version}"
     result = subprocess.run(
         [
             os.fsdecode(find_uv_bin()),
@@ -58,6 +60,7 @@ def format_url(url: str, path: str) -> str:
 def process_output(
     console: Console,
     jupyter: str,
+    jupyter_version: str | None,
     filename: str,
     output_queue: Queue,
 ):
@@ -65,7 +68,7 @@ def process_output(
     status.start()
     start = time.time()
 
-    version = get_version(jupyter)
+    version = get_version(jupyter, jupyter_version)
 
     path = {
         "lab": f"/tree/{filename}",
@@ -82,7 +85,7 @@ def process_output(
         else:
             time_str = f"[b]{elapsed_ms / 1000:.2f}[/b] s"
 
-        console.clear()
+        # console.clear()
         console.print()
         console.print(
             f"  [green][b]juv[/b] v{__version__}[/green] took {time_str}",
@@ -92,14 +95,17 @@ def process_output(
         console.print(
             f"  [dim][green b]➜[/green b]  [b]jupyter:[/b]   {jupyter} v{version}[/dim]",
             highlight=False,
+            no_wrap=True,
         )
         console.print(
             f"  [dim][green b]➜[/green b]  [b]local:[/b]     {local_url}[/dim]",
             highlight=False,
+            no_wrap=True,
         )
         console.print(
             f"  [dim][green b]➜[/green b]  [b]direct:[/b]    {direct_url}[/dim]",
             highlight=False,
+            no_wrap=True,
         )
 
     local_url = None
@@ -127,6 +133,7 @@ def run(
     args: list[str],
     filename: str,
     jupyter: typing.Literal["lab", "notebook", "nbclassic"],
+    jupyter_verison: str | None,
 ):
     console = Console()
     output_queue = Queue()
@@ -140,7 +147,7 @@ def run(
     )
     output_thread = Thread(
         target=process_output,
-        args=(console, jupyter, filename, output_queue),
+        args=(console, jupyter, jupyter_verison, filename, output_queue),
     )
     output_thread.start()
 

--- a/src/juv/_run_managed.py
+++ b/src/juv/_run_managed.py
@@ -77,7 +77,7 @@ def process_output(
         "nbclassic": f"/notebooks/{filename}",
     }[jupyter]
 
-    def display(local_url: str, direct_url: str):
+    def display(local_url: str):
         end = time.time()
         elapsed_ms = (end - start) * 1000
 
@@ -88,32 +88,21 @@ def process_output(
         )
         if clear_console:
             console.clear()
-        console.print()
         console.print(
-            f"  [green][b]juv[/b] v{__version__}[/green] took {time_str}",
-            highlight=False,
-        )
-        console.print()
-        console.print(
-            f"  [dim][green b]➜[/green b]  [b]jupyter:[/b]   {jupyter} v{version}[/dim]",
-            highlight=False,
-            no_wrap=True,
-        )
-        console.print(
-            f"  [dim][green b]➜[/green b]  [b]local:[/b]     {local_url}[/dim]",
-            highlight=False,
-            no_wrap=True,
-        )
-        console.print(
-            f"  [dim][green b]➜[/green b]  [b]direct:[/b]    {direct_url}[/dim]",
+            f"""
+  [green][b]juv[/b] v{__version__}[/green] [dim]ready in[/dim] [white]{time_str}[/white]
+
+  [green b]➜[/green b]  [b]Local:[/b]    {local_url}
+  [dim][green b]➜[/green b]  [b]Jupyter:[/b]  {jupyter} v{version}[/dim]
+  """,
             highlight=False,
             no_wrap=True,
         )
 
-    local_url, direct_url = None, None
+    local_url = None
     server_started = False
 
-    while local_url is None or direct_url is None:
+    while local_url is None:
         line = output_queue.get()
 
         if line.startswith("[") and not server_started:
@@ -124,11 +113,9 @@ def process_output(
             url = extract_url(line)
             if "localhost" in url and not local_url:
                 local_url = format_url(url, path)
-            elif not direct_url:
-                direct_url = format_url(url, path)
 
     status.stop()
-    display(local_url, direct_url)
+    display(local_url)
 
 
 def run(

--- a/src/juv/_run_managed.py
+++ b/src/juv/_run_managed.py
@@ -13,6 +13,7 @@ from threading import Thread
 import os
 import typing
 
+from uv import find_uv_bin
 
 from rich.console import Console
 
@@ -25,9 +26,9 @@ def get_version(jupyter: str):
     }[jupyter]
     result = subprocess.run(
         [
-            "uvx",
-            "--quiet",
-            "--from=jupyter-core",
+            os.fsdecode(find_uv_bin()),
+            "tool",
+            "run",
             with_jupyter,
             "jupyter",
             jupyter,
@@ -91,14 +92,15 @@ def process_output(console: Console, jupyter: str, filename: str, output_queue: 
 
 
 def run(
-    uvx_args: list[str],
+    args: list[str],
     filename: str,
     jupyter: typing.Literal["lab", "notebook", "nbclassic"],
 ):
     console = Console()
     output_queue = Queue()
+    uv = os.fsdecode(find_uv_bin())
     process = subprocess.Popen(
-        ["uvx"] + uvx_args,
+        [uv] + args,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,

--- a/src/juv/_run_managed.py
+++ b/src/juv/_run_managed.py
@@ -1,0 +1,123 @@
+"""
+Experimental UI wrapper for Jupyter commands that provides a minimal, consistent terminal interface.
+
+Manages the Jupyter process lifecycle (rather than replacing the process) and displays formatted URLs,
+while handling graceful shutdown. Supports Jupyter Lab, Notebook, and NBClassic variants.
+"""
+
+import re
+import signal
+import subprocess
+from queue import Queue
+from threading import Thread
+import os
+import typing
+
+
+from rich.console import Console
+
+
+def get_version(jupyter: str):
+    with_jupyter = {
+        "lab": "--with=jupyterlab",
+        "notebook": "--with=notebook",
+        "nbclassic": "--with=nbclassic",
+    }[jupyter]
+    result = subprocess.run(
+        [
+            "uvx",
+            "--quiet",
+            "--from=jupyter-core",
+            with_jupyter,
+            "jupyter",
+            jupyter,
+            "--version",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def extract_url(log_line: str) -> str:
+    match = re.search(r"http://[^\s]+", log_line)
+    assert match, f"URL not found in log line: {log_line}"
+    return match.group(0)
+
+
+def format_url(url: str, path: str) -> str:
+    if "?" in url:
+        url, query = url.split("?", 1)
+        return format_url(url.rstrip("/tree"), path) + f"[dim]?{query}[/dim]"
+    return f"[cyan]{re.sub(r':\d+', r'[b]\g<0>[/b]', url.rstrip("/tree"))}{path}[/cyan]"
+
+
+def process_output(console: Console, jupyter: str, filename: str, output_queue: Queue):
+    version = get_version(jupyter)
+    name = f"jupyter {jupyter}".upper()
+
+    console.clear()
+    version_str = f" v{version}" if version else ""
+    console.print()
+    console.print(f"  [green][b]{name}[/b]{version_str}[/green]")
+    console.print()
+
+    local_url = False
+    direct_url = False
+
+    path = {
+        "lab": f"/tree/{filename}",
+        "notebook": f"/notebooks/{filename}",
+        "nbclassic": f"/notebooks/{filename}",
+    }[jupyter]
+
+    while True:
+        line = output_queue.get()
+        if line is None:
+            break
+
+        if "http://" in line:
+            url = extract_url(line)
+            if "localhost" in url and not local_url:
+                console.print(
+                    f"  [green b]➜[/green b]  [b]Local:[/b]   {format_url(url, path)}"
+                )
+                local_url = True
+            elif not direct_url:
+                console.print(
+                    f"  [dim][green b]➜[/green b]  [b]Direct:[/b]  {format_url(url, path)}[/dim]"
+                )
+                direct_url = True
+
+
+def run(
+    uvx_args: list[str],
+    filename: str,
+    jupyter: typing.Literal["lab", "notebook", "nbclassic"],
+):
+    console = Console()
+    output_queue = Queue()
+    process = subprocess.Popen(
+        ["uvx"] + uvx_args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        preexec_fn=os.setsid,
+    )
+    output_thread = Thread(
+        target=process_output, args=(console, jupyter, filename, output_queue)
+    )
+    output_thread.start()
+
+    try:
+        while True and process.stdout:
+            line = process.stdout.readline()
+            if not line and process.poll() is not None:
+                break
+            output_queue.put(line)
+    except KeyboardInterrupt:
+        with console.status("Shutting down..."):
+            os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+    finally:
+        output_queue.put(None)
+        output_thread.join()

--- a/src/juv/_run_managed.py
+++ b/src/juv/_run_managed.py
@@ -65,7 +65,7 @@ def process_output(
     output_queue: Queue,
     clear_console: bool = False,
 ):
-    status = console.status("Starting Jupyter Server", spinner="dots")
+    status = console.status("Running uv...", spinner="dots")
     status.start()
     start = time.time()
 
@@ -111,8 +111,14 @@ def process_output(
         )
 
     local_url, direct_url = None, None
+    server_started = False
+
     while local_url is None or direct_url is None:
         line = output_queue.get()
+
+        if line.startswith("[") and not server_started:
+            status.update("Jupyter server started", spinner="dots")
+            server_started = True
 
         if "http://" in line:
             url = extract_url(line)


### PR DESCRIPTION
Idea from @dvdkouril.

The juptyer-server logs are really verbose and using the `--log-level` flag doesn't do very much in terms of filtering.

The default behavior of `juv run` will be to _replace_ the current process with the one spawned by `uvx <jupyter command>`. However, this PR adds a new enviroment variable `JUV_RUN_MODE=[replace|managed]` that will allow the user to choose between the two modes.

The managed mode will spawn a child process with a consistent but more minimal UI in the terminal.


https://github.com/user-attachments/assets/a63c6d96-bbe5-4fa1-a45c-9d78b607b1c8


We may change the default behavior in the future in a minor release, but for now I'm likely going to be using this myself and we can start iterating on more features for the "managed" mode.
