### PR TITLE
Add `edit` command for quick editing in default editor

### DIFF
--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -129,6 +129,32 @@ def clear(files: list[str]) -> None:
     rich.print(f"Cleared output from {len(paths)} notebooks", file=sys.stderr)
 
 
+@cli.command()
+@click.argument("notebook", type=click.Path(exists=True), required=True)
+@click.option(
+    "--format",
+    type=click.Choice(["markdown", "py:percent"]),
+    default="py:percent",
+    help="The format for editing the notebook in a temporary file.",
+)
+@click.option("--editor", type=click.STRING, required=False)
+def edit(notebook: str, format: str, editor: str | None) -> None:  # noqa: A002
+    """Edit a notebook in the default editor."""
+    from ._edit import edit
+
+    if editor is None:
+        editor = os.environ.get("EDITOR")
+
+    if editor is None:
+        msg = (
+            "No editor specified. Please set the EDITOR environment variable "
+            "or use the --editor option."
+        )
+        raise click.UsageError(msg)  # noqa: DOC501
+
+    edit(path=Path(notebook), editor=editor, format_=format)
+
+
 def upgrade_legacy_jupyter_command(args: list[str]) -> None:
     """Check legacy command usage and upgrade to 'run' with deprecation notice."""
     if len(args) >= 2:  # noqa: PLR2004

--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -139,7 +139,7 @@ def clear(files: list[str]) -> None:
 )
 @click.option("--editor", type=click.STRING, required=False)
 def edit(notebook: str, format: str, editor: str | None) -> None:  # noqa: A002
-    """Edit a notebook in the default editor."""
+    """Quick edit a notebook in default editor."""
     from ._edit import EditorAbortedError, edit
 
     if editor is None:

--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -133,7 +133,7 @@ def clear(files: list[str]) -> None:
 @click.argument("notebook", type=click.Path(exists=True), required=True)
 @click.option(
     "--format",
-    type=click.Choice(["markdown", "py:percent"]),
+    type=click.Choice(["markdown", "py:percent", "py", "md"]),
     default="py:percent",
     help="The format for editing the notebook in a temporary file.",
 )
@@ -150,10 +150,23 @@ def edit(notebook: str, format: str, editor: str | None) -> None:  # noqa: A002
             "No editor specified. Please set the EDITOR environment variable "
             "or use the --editor option."
         )
-        raise click.UsageError(msg)
+        rich.print(f"[bold red]Error:[/bold red] {msg}", file=sys.stderr)
+        return
+
+    path = Path(notebook)
+    if path.suffix != ".ipynb":
+        rich.print(
+            f"[bold red]Error:[/bold red] `[cyan]{path}[/cyan]` is not a notebook",
+            file=sys.stderr,
+        )
+        return
 
     try:
-        edit(path=Path(notebook), editor=editor, format_=format)
+        edit(
+            path=path,
+            editor=editor,
+            format_={"md": "markdown", "py": "py:percent"}.get(format, format),
+        )
         rich.print(f"Edited `[cyan]{notebook}[/cyan]`")
     except EditorAbortedError as e:
         rich.print(f"[bold red]Error:[/bold red] {e}", file=sys.stderr)

--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -140,7 +140,7 @@ def clear(files: list[str]) -> None:
 @click.option("--editor", type=click.STRING, required=False)
 def edit(notebook: str, format: str, editor: str | None) -> None:  # noqa: A002
     """Edit a notebook in the default editor."""
-    from ._edit import edit
+    from ._edit import EditorAbortedError, edit
 
     if editor is None:
         editor = os.environ.get("EDITOR")
@@ -150,9 +150,13 @@ def edit(notebook: str, format: str, editor: str | None) -> None:  # noqa: A002
             "No editor specified. Please set the EDITOR environment variable "
             "or use the --editor option."
         )
-        raise click.UsageError(msg)  # noqa: DOC501
+        raise click.UsageError(msg)
 
-    edit(path=Path(notebook), editor=editor, format_=format)
+    try:
+        edit(path=Path(notebook), editor=editor, format_=format)
+        rich.print(f"Edited `[cyan]{notebook}[/cyan]`")
+    except EditorAbortedError as e:
+        rich.print(f"[bold red]Error:[/bold red] {e}", file=sys.stderr)
 
 
 def upgrade_legacy_jupyter_command(args: list[str]) -> None:

--- a/src/juv/_edit.py
+++ b/src/juv/_edit.py
@@ -1,0 +1,38 @@
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import jupytext
+
+
+def open_editor(contents: str, suffix: str, editor: str) -> str:
+    """Open an editor with the given contents and return the modified text."""
+    with tempfile.NamedTemporaryFile(
+        suffix=suffix, mode="w+", delete=False, encoding="utf-8"
+    ) as tf:
+        # Write initial text if provided
+        if contents:
+            tf.write(contents)
+            tf.flush()
+
+        temp_filename = tf.name
+
+    try:
+        subprocess.call([editor, temp_filename])
+
+        return Path(temp_filename).read_text(encoding="utf-8")
+
+    finally:
+        # Clean up the temporary file
+        Path(temp_filename).unlink()
+
+
+def edit(path: Path, format_: str, editor: str) -> None:
+    contents = jupytext.read(path, fmt="ipynb")
+    fmt = "md" if format_ == "markdown" else "py:percent"
+    suffix = ".md" if fmt == "md" else ".py"
+    contents = jupytext.writes(contents, fmt=fmt)
+    text = open_editor(contents, suffix=suffix, editor=editor)
+    notebook = jupytext.reads(text, fmt=fmt)
+    path.write_text(jupytext.writes(notebook, fmt="ipynb"))

--- a/src/juv/_edit.py
+++ b/src/juv/_edit.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 import tempfile
 from pathlib import Path
@@ -6,33 +5,58 @@ from pathlib import Path
 import jupytext
 
 
+class EditorAbortedError(Exception):
+    """Exception raised when the editor exits abnormally."""
+
+
 def open_editor(contents: str, suffix: str, editor: str) -> str:
-    """Open an editor with the given contents and return the modified text."""
+    """Open an editor with the given contents and return the modified text.
+
+    Args:
+        contents: Initial text content
+        suffix: File extension for temporary file
+        editor: Editor command to use
+
+    Returns:
+        str: Modified text content
+
+    Raises:
+        EditorAbortedError: If editor exits abnormally
+
+    """
     with tempfile.NamedTemporaryFile(
         suffix=suffix, mode="w+", delete=False, encoding="utf-8"
     ) as tf:
-        # Write initial text if provided
         if contents:
             tf.write(contents)
             tf.flush()
-
-        temp_filename = tf.name
-
+        tpath = Path(tf.name)
     try:
-        subprocess.call([editor, temp_filename])
-
-        return Path(temp_filename).read_text(encoding="utf-8")
-
+        result = subprocess.run([editor, tpath], check=False)  # noqa: S603
+        if result.returncode != 0:
+            msg = f"Editor exited with code {result.returncode}"
+            raise EditorAbortedError(msg)
+        return tpath.read_text(encoding="utf-8")
     finally:
-        # Clean up the temporary file
-        Path(temp_filename).unlink()
+        tpath.unlink()
 
 
 def edit(path: Path, format_: str, editor: str) -> None:
+    """Edit a Jupyter notebook in the specified format.
+
+    Args:
+        path: Path to notebook file
+        format_: Target format ('markdown' or 'python')
+        editor: Editor command to use
+
+    """
     contents = jupytext.read(path, fmt="ipynb")
     fmt = "md" if format_ == "markdown" else "py:percent"
     suffix = ".md" if fmt == "md" else ".py"
     contents = jupytext.writes(contents, fmt=fmt)
+
     text = open_editor(contents, suffix=suffix, editor=editor)
+
+    # Only process the notebook if editor completed normally
     notebook = jupytext.reads(text, fmt=fmt)
     path.write_text(jupytext.writes(notebook, fmt="ipynb"))


### PR DESCRIPTION
Adds `juv edit Untitled.ipynb # [--format=[markdown|py:percent]]`. Uses the default editor or `--editor` for editing the file, writing the contents back out as a notebook.

