### PR TITLE
Require editing in markdown for better diffs

### DIFF
--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -132,7 +132,7 @@ def clear(files: list[str]) -> None:
 @cli.command()
 @click.argument("notebook", type=click.Path(exists=True), required=True)
 @click.option("--editor", type=click.STRING, required=False)
-def edit(notebook: str, editor: str | None) -> None:  # noqa: A002
+def edit(notebook: str, editor: str | None) -> None:
     """Quick edit a notebook as markdown."""
     from ._edit import EditorAbortedError, edit
 

--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -131,15 +131,9 @@ def clear(files: list[str]) -> None:
 
 @cli.command()
 @click.argument("notebook", type=click.Path(exists=True), required=True)
-@click.option(
-    "--format",
-    type=click.Choice(["markdown", "py:percent", "py", "md"]),
-    default="py:percent",
-    help="The format for editing the notebook in a temporary file.",
-)
 @click.option("--editor", type=click.STRING, required=False)
-def edit(notebook: str, format: str, editor: str | None) -> None:  # noqa: A002
-    """Quick edit a notebook in default editor."""
+def edit(notebook: str, editor: str | None) -> None:  # noqa: A002
+    """Quick edit a notebook as markdown."""
     from ._edit import EditorAbortedError, edit
 
     if editor is None:
@@ -162,11 +156,7 @@ def edit(notebook: str, format: str, editor: str | None) -> None:  # noqa: A002
         return
 
     try:
-        edit(
-            path=path,
-            editor=editor,
-            format_={"md": "markdown", "py": "py:percent"}.get(format, format),
-        )
+        edit(path=path, editor=editor)
         rich.print(f"Edited `[cyan]{notebook}[/cyan]`")
     except EditorAbortedError as e:
         rich.print(f"[bold red]Error:[/bold red] {e}", file=sys.stderr)

--- a/src/juv/_cat.py
+++ b/src/juv/_cat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from pathlib import Path
 
@@ -36,9 +38,9 @@ def strip_python_frontmatter_comment(content: str) -> tuple[str, str]:
     return "", content
 
 
-def cat(path: Path, fmt: str) -> str:
+def cat(nb: Path | dict, fmt: str) -> str:
     fmt = {"markdown": "md", "py:percent": "py", "md": "md", "py": "py"}[fmt]
-    notebook = jupytext.read(path)
+    notebook = nb if isinstance(nb, dict) else jupytext.read(nb)
     contents = jupytext.writes(notebook, fmt=fmt)
     if fmt == "md":
         _, contents = strip_markdown_header(contents)

--- a/src/juv/_cat.py
+++ b/src/juv/_cat.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import re
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import jupytext
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def strip_markdown_header(content: str) -> tuple[str, str]:

--- a/src/juv/_edit.py
+++ b/src/juv/_edit.py
@@ -1,7 +1,7 @@
 import subprocess
 import tempfile
-from pathlib import Path
 from itertools import zip_longest
+from pathlib import Path
 
 import jupytext
 


### PR DESCRIPTION
The py:percent syntax is harder to resolve and markdown is much more explict. We could bring it back but for now this works.
