### PR TITLE
Support forwarding flags to underlying Jupyter front end

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ ignore = [
     "SLF001", # Access private member
     "W291",   # Trailing whitespace
     "INP001", # Allow implicit namespace
+    "E501",   # Allow long lines (snapshots)
+    "PLC2701" # Import private member
 ]
 
 [tool.rooster]
@@ -73,3 +75,4 @@ changelog_sections.bug = "Bug fixes"
 changelog_sections.documentation = "Documentation"
 changelog_sections.__unknown__ = "Other changes"
 changelog_contributors = true
+

--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -71,11 +71,15 @@ def add(file: str, requirements: str | None, packages: tuple[str, ...]) -> None:
 )
 @click.option("--with", "with_args", type=click.STRING, multiple=True)
 @click.option("--python", type=click.STRING, required=False)
+@click.argument(
+    "jupyter_args", nargs=-1, type=click.UNPROCESSED
+)  # Capture all args after --
 def run(
     file: str,
     jupyter: str | None,
     with_args: tuple[str, ...],
     python: str | None,
+    jupyter_args: tuple[str, ...],
 ) -> None:
     """Launch a notebook or script in a Jupyter front end."""
     from ._run import run
@@ -85,6 +89,7 @@ def run(
         jupyter=jupyter,
         python=python,
         with_args=with_args,
+        jupyter_args=jupyter_args,
     )
 
 

--- a/src/juv/_run.py
+++ b/src/juv/_run.py
@@ -95,12 +95,14 @@ def to_notebook(fp: Path) -> tuple[str | None, dict]:
     return meta, nb
 
 
-def prepare_uv_tool_run_args(
+def prepare_uv_tool_run_args(  # noqa: PLR0913
+    *,
     target: Path,
     runtime: Runtime,
     meta: Pep723Meta,
     python: str | None,
     extra_with_args: typing.Sequence[str],
+    jupyter_args: typing.Sequence[str],
 ) -> list[str]:
     jupyter_dependency = {
         "notebook": "notebook",
@@ -125,6 +127,7 @@ def prepare_uv_tool_run_args(
         *(["--with=" + ",".join(extra_with_args)] if extra_with_args else []),
         "jupyter",
         runtime.name,
+        *jupyter_args,
         str(target),
     ]
 
@@ -134,6 +137,7 @@ def run(
     jupyter: str | None,
     python: str | None,
     with_args: typing.Sequence[str],
+    jupyter_args: typing.Sequence[str],
 ) -> None:
     """Launch a notebook or script."""
     runtime = parse_notebook_specifier(jupyter)
@@ -152,7 +156,12 @@ def run(
         meta=Pep723Meta.from_toml(meta) if meta else Pep723Meta([], None),
         python=python,
         extra_with_args=with_args,
+        jupyter_args=jupyter_args,
     )
+
+    if os.environ.get("JUV_DEBUG") == "1":
+        print(f"uv {' '.join(args)}")  # noqa: T201
+        return
 
     if os.environ.get("JUV_RUN_MODE") == "managed":
         from ._run_managed import run as run_managed

--- a/src/juv/_run_managed.py
+++ b/src/juv/_run_managed.py
@@ -113,8 +113,7 @@ def process_output(
 
         if "http://" in line:
             url = extract_url(line)
-            if "localhost" in url and not local_url:
-                local_url = format_url(url, path)
+            local_url = format_url(url, path)
 
     status.stop()
     display(local_url)


### PR DESCRIPTION
Adds the ability to pass down subcommand arguments to underlying jupyter frontend:


```sh
juv run Untitled.ipynb -- --no-browser
```

The subcommand arguments follow the `--` separator and are not parsed by the `juv` command itself.

This PR also adds a `JUV_DEBUG` flag, which in tests will just print the uv command to the CLI instead of running it.
