### PR TITLE
Support `add --extra`

### DIFF
--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -52,12 +52,18 @@ def init(
 @cli.command()
 @click.argument("file", type=click.Path(exists=True), required=True)
 @click.option("--requirements", "-r", type=click.Path(exists=True), required=False)
+@click.option("--extra", "extras", type=click.STRING, multiple=True)
 @click.argument("packages", nargs=-1)
-def add(file: str, requirements: str | None, packages: tuple[str, ...]) -> None:
+def add(
+    file: str,
+    requirements: str | None,
+    extras: tuple[str, ...],
+    packages: tuple[str, ...],
+) -> None:
     """Add dependencies to a notebook."""
     from ._add import add
 
-    add(path=Path(file), packages=packages, requirements=requirements)
+    add(path=Path(file), packages=packages, requirements=requirements, extras=extras)
     path = os.path.relpath(Path(file).resolve(), Path.cwd())
     rich.print(f"Updated `[cyan]{path}[/cyan]`")
 

--- a/src/juv/_add.py
+++ b/src/juv/_add.py
@@ -34,7 +34,12 @@ def find(cb: typing.Callable[[T], bool], items: list[T]) -> T | None:
     return next((item for item in items if cb(item)), None)
 
 
-def add(path: Path, packages: typing.Sequence[str], requirements: str | None) -> None:
+def add(
+    path: Path,
+    packages: typing.Sequence[str],
+    requirements: str | None,
+    extras: typing.Sequence[str],
+) -> None:
     notebook = jupytext.read(path, fmt="ipynb")
 
     # need a reference so we can modify the cell["source"]
@@ -64,6 +69,7 @@ def add(path: Path, packages: typing.Sequence[str], requirements: str | None) ->
             [
                 "add",
                 *(["--requirements", requirements] if requirements else []),
+                *([f"--extra={extra}" for extra in extras]),
                 "--script",
                 f.name,
                 *packages,

--- a/src/juv/_init.py
+++ b/src/juv/_init.py
@@ -94,6 +94,6 @@ def init(
     if len(packages) > 0:
         from ._add import add
 
-        add(path=path, packages=packages, requirements=None)
+        add(path=path, packages=packages, requirements=None, extras=[])
 
     return path


### PR DESCRIPTION
Supports using the `--extra` flag for `add`.

Include optional dependencies from the specified extra name.

May be provided more than once.

```sh
juv add Untitled.ipynb --extra dev anywidget # adds `anywidget[dev]`
```
