### PR TITLE
Support `--editable` sources for `add`

### DIFF
--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -53,17 +53,26 @@ def init(
 @click.argument("file", type=click.Path(exists=True), required=True)
 @click.option("--requirements", "-r", type=click.Path(exists=True), required=False)
 @click.option("--extra", "extras", type=click.STRING, multiple=True)
+@click.option("--editable", is_flag=True)
 @click.argument("packages", nargs=-1)
 def add(
     file: str,
     requirements: str | None,
     extras: tuple[str, ...],
     packages: tuple[str, ...],
+    *,
+    editable: bool,
 ) -> None:
     """Add dependencies to a notebook."""
     from ._add import add
 
-    add(path=Path(file), packages=packages, requirements=requirements, extras=extras)
+    add(
+        path=Path(file),
+        packages=packages,
+        requirements=requirements,
+        extras=extras,
+        editable=editable,
+    )
     path = os.path.relpath(Path(file).resolve(), Path.cwd())
     rich.print(f"Updated `[cyan]{path}[/cyan]`")
 

--- a/src/juv/_add.py
+++ b/src/juv/_add.py
@@ -37,8 +37,10 @@ def find(cb: typing.Callable[[T], bool], items: list[T]) -> T | None:
 def add(
     path: Path,
     packages: typing.Sequence[str],
-    requirements: str | None,
-    extras: typing.Sequence[str],
+    requirements: str | None = None,
+    extras: typing.Sequence[str] | None = None,
+    *,
+    editable: bool = False,
 ) -> None:
     notebook = jupytext.read(path, fmt="ipynb")
 
@@ -69,7 +71,8 @@ def add(
             [
                 "add",
                 *(["--requirements", requirements] if requirements else []),
-                *([f"--extra={extra}" for extra in extras]),
+                *([f"--extra={extra}" for extra in extras or []]),
+                *(["--editable"] if editable else []),
                 "--script",
                 f.name,
                 *packages,

--- a/src/juv/_init.py
+++ b/src/juv/_init.py
@@ -94,6 +94,6 @@ def init(
     if len(packages) > 0:
         from ._add import add
 
-        add(path=path, packages=packages, requirements=None, extras=[])
+        add(path=path, packages=packages)
 
     return path

--- a/tests/test_juv.py
+++ b/tests/test_juv.py
@@ -625,7 +625,17 @@ def test_add_local_package(
 
     assert result.exit_code == 0
     assert result.stdout == snapshot("Updated `test.ipynb`\n")
-    assert extract_meta_cell(tmp_path / "test.ipynb") == snapshot()
+    assert extract_meta_cell(tmp_path / "test.ipynb") == snapshot("""\
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "foo",
+# ]
+#
+# [tool.uv.sources]
+# foo = { path = "foo" }
+# ///\
+""")
 
 
 def test_add_local_package_as_editable(
@@ -640,4 +650,14 @@ def test_add_local_package_as_editable(
 
     assert result.exit_code == 0
     assert result.stdout == snapshot("Updated `test.ipynb`\n")
-    assert extract_meta_cell(tmp_path / "test.ipynb") == snapshot()
+    assert extract_meta_cell(tmp_path / "test.ipynb") == snapshot("""\
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "foo",
+# ]
+#
+# [tool.uv.sources]
+# foo = { path = "foo", editable = true }
+# ///\
+""")

--- a/tests/test_juv.py
+++ b/tests/test_juv.py
@@ -14,6 +14,7 @@ from juv import cli
 from juv._nbutils import write_ipynb
 from juv._pep723 import parse_inline_script_metadata
 from juv._run import to_notebook
+from juv._uv import uv
 
 if TYPE_CHECKING:
     import pathlib
@@ -610,3 +611,33 @@ def test_add_with_extras(
 # ]
 # ///\
 """)
+
+
+def test_add_local_package(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    uv(["init", "--lib", "foo"], check=True)
+    invoke(["init", "test.ipynb"])
+    result = invoke(["add", "test.ipynb", "./foo"])
+
+    assert result.exit_code == 0
+    assert result.stdout == snapshot("Updated `test.ipynb`\n")
+    assert extract_meta_cell(tmp_path / "test.ipynb") == snapshot()
+
+
+def test_add_local_package_as_editable(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    uv(["init", "--lib", "foo"], check=True)
+    invoke(["init", "test.ipynb"])
+    result = invoke(["add", "test.ipynb", "--editable", "./foo"])
+
+    assert result.exit_code == 0
+    assert result.stdout == snapshot("Updated `test.ipynb`\n")
+    assert extract_meta_cell(tmp_path / "test.ipynb") == snapshot()


### PR DESCRIPTION
Adds the `--editable` flag to `add` to the requirements as editable (e.g., a local package).

```sh
juv add Untitled.ipynb --editable ./path/to/package
```
