### PR TITLE
Change directories prior to running uv

### DIFF
--- a/src/juv/_exec.py
+++ b/src/juv/_exec.py
@@ -19,7 +19,12 @@ def exec_(
     *,
     quiet: bool,
 ) -> None:
-    notebook = jupytext.read(path)
+    target = path.resolve()
+    notebook = jupytext.read(target)
+
+    # change to the target's directory
+    os.chdir(target.parent)
+
     subprocess.run(  # noqa: S603
         [
             os.fsdecode(find_uv_bin()),

--- a/src/juv/_run.py
+++ b/src/juv/_run.py
@@ -64,15 +64,20 @@ def run(
             f"Converted script to notebook `[cyan]{path.resolve().absolute()}[/cyan]`",
         )
 
+    target = path.resolve()
+
     script, args = prepare_run_script_and_uv_run_args(
         runtime=runtime,
-        target=path,
+        target=target,
         meta=meta or "",
         python=python,
         with_args=with_args,
         jupyter_args=jupyter_args,
         no_project=True,
     )
+
+    # change to the directory of the script/notebook before running uv
+    os.chdir(target.parent)
 
     if os.environ.get("JUV_RUN_MODE") == "dry":
         print(f"uv {' '.join(args)}")  # noqa: T201


### PR DESCRIPTION
Since we now pipe the contents of the script into uv via `stdin` we need to change directories to the directory with the script to resolution of inline metadata is resolved correctly.
