### PR TITLE
Add `--check` flag for `juv clear`

### DIFF
--- a/src/juv/_clear.py
+++ b/src/juv/_clear.py
@@ -15,3 +15,12 @@ def clear(path: Path) -> None:
             cell.outputs = []
             cell.execution_count = None
     nbformat.write(nb, path)
+
+
+def is_cleared(path: Path) -> bool:
+    """Check if a notebook has been cleared."""
+    nb = nbformat.read(path, nbformat.NO_CONVERT)
+    for cell in filter(lambda cell: cell.cell_type == "code", nb.cells):
+        if cell.outputs or cell.execution_count is not None:
+            return False
+    return True


### PR DESCRIPTION
Adds `--check` flag to `juv clear` to assert cell execution count and output are empty. Useful for CI/CD pipelines.
