### PR TITLE
Add `--pin` flag for `juv add`

### DIFF
--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -88,7 +88,9 @@ def init(
 @click.option(
     "--rev", type=click.STRING, help="Commit to use when adding a dependency from Git."
 )
-@click.option("--exact", is_flag=True, help="Resolve packages to exact versions.")
+@click.option(
+    "--pin", is_flag=True, help="Resolve package specifiers to exact versions and pin."
+)
 @click.option(
     "--exclude-newer",
     type=click.STRING,
@@ -108,7 +110,7 @@ def add(  # noqa: PLR0913
     branch: str | None,
     rev: str | None,
     editable: bool,
-    exact: bool,
+    pin: bool,
     exclude_newer: str | None,
 ) -> None:
     """Add dependencies to a notebook or script."""
@@ -123,7 +125,7 @@ def add(  # noqa: PLR0913
         tag=tag,
         branch=branch,
         rev=rev,
-        exact=exact,
+        pin=pin,
         exclude_newer=exclude_newer,
     )
     path = os.path.relpath(Path(file).resolve(), Path.cwd())

--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -88,6 +88,15 @@ def init(
 @click.option(
     "--rev", type=click.STRING, help="Commit to use when adding a dependency from Git."
 )
+@click.option("--exact", is_flag=True, help="Resolve packages to exact versions.")
+@click.option(
+    "--exclude-newer",
+    is_flag=True,
+    help=(
+        "Limit candidate packages to those that were uploaded prior to the given date "
+        "[env: UV_EXCLUDE_NEWER=]"
+    ),
+)
 @click.argument("packages", nargs=-1)
 def add(  # noqa: PLR0913
     *,
@@ -99,8 +108,10 @@ def add(  # noqa: PLR0913
     branch: str | None,
     rev: str | None,
     editable: bool,
+    exact: bool,
+    exclude_newer: bool,
 ) -> None:
-    """Add dependencies to a notebook."""
+    """Add dependencies to a notebook or script."""
     from ._add import add
 
     add(
@@ -112,6 +123,8 @@ def add(  # noqa: PLR0913
         tag=tag,
         branch=branch,
         rev=rev,
+        exact=exact,
+        exclude_newer=exclude_newer,
     )
     path = os.path.relpath(Path(file).resolve(), Path.cwd())
     rich.print(f"Updated `[cyan]{path}[/cyan]`")

--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -91,7 +91,7 @@ def init(
 @click.option("--exact", is_flag=True, help="Resolve packages to exact versions.")
 @click.option(
     "--exclude-newer",
-    is_flag=True,
+    type=click.STRING,
     help=(
         "Limit candidate packages to those that were uploaded prior to the given date "
         "[env: UV_EXCLUDE_NEWER=]"
@@ -109,7 +109,7 @@ def add(  # noqa: PLR0913
     rev: str | None,
     editable: bool,
     exact: bool,
-    exclude_newer: bool,
+    exclude_newer: str | None,
 ) -> None:
     """Add dependencies to a notebook or script."""
     from ._add import add

--- a/src/juv/_add.py
+++ b/src/juv/_add.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import tempfile
 import typing
+from pathlib import Path
 
 import jupytext
+from jupytext.pandoc import subprocess
+from uv import find_uv_bin
 
 from ._nbutils import code_cell, write_ipynb
 from ._pep723 import includes_inline_metadata
 from ._uv import uv
-
-if typing.TYPE_CHECKING:
-    from pathlib import Path
 
 T = typing.TypeVar("T")
 
@@ -34,16 +34,79 @@ def find(cb: typing.Callable[[T], bool], items: list[T]) -> T | None:
     return next((item for item in items if cb(item)), None)
 
 
-def add(  # noqa: PLR0913
-    path: Path,
+def uv_pip_compile(
     packages: typing.Sequence[str],
-    requirements: str | None = None,
-    extras: typing.Sequence[str] | None = None,
-    tag: str | None = None,
-    branch: str | None = None,
-    rev: str | None = None,
+    requirements: str | None,
     *,
-    editable: bool = False,
+    no_deps: bool,
+) -> list[str]:
+    """Use `pip compile` to generate exact versions of packages."""
+    requirements_txt = "" if requirements is None else Path(requirements).read_text()
+
+    # just append the packages on to the requirements
+    for package in packages:
+        if package not in requirements_txt:
+            requirements_txt += f"{package}\n"
+
+    result = subprocess.run(
+        [
+            find_uv_bin(),
+            "pip",
+            "compile",
+            *(["--no-deps"] if no_deps else []),
+            "-",
+        ],
+        input=requirements_txt.encode("utf-8"),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+    # filter only for the exact versions
+    return [pkg for pkg in result.stdout.decode().split("\n") if "==" in pkg]
+
+
+def uv_script(  # noqa: PLR0913
+    script: Path | str,
+    *,
+    packages: typing.Sequence[str],
+    requirements: str | None,
+    extras: typing.Sequence[str] | None,
+    editable: bool,
+    branch: str | None,
+    rev: str | None,
+    tag: str | None,
+    exclude_newer: bool = False,
+) -> None:
+    uv(
+        [
+            "add",
+            *(["--requirements", requirements] if requirements else []),
+            *([f"--extra={extra}" for extra in extras or []]),
+            *(["--editable"] if editable else []),
+            *([f"--tag={tag}"] if tag else []),
+            *([f"--branch={branch}"] if branch else []),
+            *([f"--rev={rev}"] if rev else []),
+            *(["--exclude-newer"] if exclude_newer else []),
+            "--script",
+            str(script),
+            *packages,
+        ],
+        check=True,
+    )
+
+
+def add_notebook(  # noqa: PLR0913
+    path: Path,
+    *,
+    packages: typing.Sequence[str],
+    requirements: str | None,
+    extras: typing.Sequence[str] | None,
+    editable: bool,
+    branch: str | None,
+    rev: str | None,
+    tag: str | None,
+    exclude_newer: bool = False,
 ) -> None:
     notebook = jupytext.read(path, fmt="ipynb")
 
@@ -69,24 +132,48 @@ def add(  # noqa: PLR0913
     ) as f:
         f.write(cell["source"].strip())
         f.flush()
-
-        uv(
-            [
-                "add",
-                *(["--requirements", requirements] if requirements else []),
-                *([f"--extra={extra}" for extra in extras or []]),
-                *(["--editable"] if editable else []),
-                *([f"--tag={tag}"] if tag else []),
-                *([f"--branch={branch}"] if branch else []),
-                *([f"--rev={rev}"] if rev else []),
-                "--script",
-                f.name,
-                *packages,
-            ],
-            check=True,
+        uv_script(
+            script=f.name,
+            packages=packages,
+            requirements=requirements,
+            extras=extras,
+            editable=editable,
+            branch=branch,
+            rev=rev,
+            tag=tag,
+            exclude_newer=exclude_newer,
         )
-
         f.seek(0)
         cell["source"] = f.read().strip()
 
     write_ipynb(notebook, path.with_suffix(".ipynb"))
+
+
+def add(  # noqa: PLR0913
+    *,
+    path: Path,
+    packages: typing.Sequence[str],
+    requirements: str | None = None,
+    extras: typing.Sequence[str] | None = None,
+    tag: str | None = None,
+    branch: str | None = None,
+    rev: str | None = None,
+    exact: bool = False,
+    editable: bool = False,
+    exclude_newer: bool = False,
+) -> None:
+    if exact:
+        packages = uv_pip_compile(packages, requirements, no_deps=True)
+        requirements = None
+
+    (add_notebook if path.suffix == ".ipynb" else uv_script)(
+        path,
+        packages=packages,
+        requirements=requirements,
+        extras=extras,
+        editable=editable,
+        branch=branch,
+        rev=rev,
+        tag=tag,
+        exclude_newer=exclude_newer,
+    )

--- a/src/juv/_add.py
+++ b/src/juv/_add.py
@@ -160,11 +160,11 @@ def add(  # noqa: PLR0913
     tag: str | None = None,
     branch: str | None = None,
     rev: str | None = None,
-    exact: bool = False,
+    pin: bool = False,
     editable: bool = False,
     exclude_newer: str | None = None,
 ) -> None:
-    if exact:
+    if pin:
         packages = uv_pip_compile(
             packages, requirements, exclude_newer=exclude_newer, no_deps=True
         )

--- a/tests/test_juv.py
+++ b/tests/test_juv.py
@@ -897,14 +897,14 @@ def test_stamp_clear(
 """)
 
 
-def test_add_exact_notebook(
+def test_add_notebook_pinned(
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.chdir(tmp_path)
 
     invoke(["init", "test.ipynb"])
-    result = invoke(["add", "test.ipynb", "--exact", "anywidget"])
+    result = invoke(["add", "test.ipynb", "anywidget", "--pin"])
     assert result.exit_code == 0
     assert result.stdout == snapshot("Updated `test.ipynb`\n")
     assert extract_meta_cell(tmp_path / "test.ipynb") == snapshot("""\
@@ -917,7 +917,7 @@ def test_add_exact_notebook(
 """)
 
 
-def test_add_exact_script(
+def test_add_script_pinned(
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -932,7 +932,7 @@ def test_add_exact_script(
 print("Hello from foo.py!")
 """)
 
-    result = invoke(["add", "foo.py", "--exact", "anywidget"])
+    result = invoke(["add", "foo.py", "anywidget", "--pin"])
     assert result.exit_code == 0
     assert result.stdout == snapshot("Updated `foo.py`\n")
     assert (tmp_path / "foo.py").read_text() == snapshot("""\

--- a/tests/test_juv.py
+++ b/tests/test_juv.py
@@ -31,7 +31,7 @@ def invoke(args: list[str], uv_python: str = "3.13") -> Result:
             "JUV_RUN_MODE": "dry",
             "JUV_JUPYTER": "lab",
             "JUV_TZ": "America/New_York",
-            "UV_EXCLUDE_NEWER": "2024-07-07T00:00:00-02:00",
+            "UV_EXCLUDE_NEWER": "2023-02-01T00:00:00-02:00",
         },
     )
 
@@ -911,7 +911,7 @@ def test_add_exact_notebook(
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "anywidget==0.9.13",
+#     "anywidget==0.1.0",
 # ]
 # ///\
 """)
@@ -939,7 +939,7 @@ print("Hello from foo.py!")
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "anywidget==0.9.13",
+#     "anywidget==0.1.0",
 # ]
 # ///
 


### PR DESCRIPTION
Adds a `--pin` flag to `juv add` to resolve packages to a specific version. This will effectively pin the package in the notebook/script to whatever the resolver finds at the time of the command.

Works with both scripts and notebooks.

```sh
uvx juv init
uvx juv add Untitled.ipynb numpy polars --pin # adds numpy==2.1.3 polars==1.13.1
```

```sh
uv init --script foo.py
uvx juv add foo.py numpy polars --pin
```
