### PR TITLE
Add kernelspec metadata to new notebooks

### DIFF
--- a/src/juv/_nbutils.py
+++ b/src/juv/_nbutils.py
@@ -18,7 +18,14 @@ def code_cell(source: str, *, hidden: bool = False) -> dict:
 
 
 def new_notebook(cells: list[dict]) -> dict:
-    return nb.new_notebook(cells=cells)
+    notebook = nb.new_notebook(cells=cells)
+    if "kernelspec" not in notebook.metadata:
+        notebook.metadata.kernelspec = {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3",
+        }
+    return notebook
 
 
 def write_ipynb(nb: dict, file: Path) -> None:

--- a/tests/test_juv.py
+++ b/tests/test_juv.py
@@ -464,7 +464,13 @@ def test_init_creates_notebook_with_inline_meta(
    "source": []
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }\
@@ -511,7 +517,13 @@ def test_init_creates_notebook_with_specific_python_version(
    "source": []
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }\
@@ -573,7 +585,13 @@ def test_init_with_deps(
    "source": []
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }\


### PR DESCRIPTION
Adds default `kernelspec` metadata when initializing notebooks
