### PR TITLE
Support windows with `juv run`

### DIFF
--- a/src/juv/_run_replace.py
+++ b/src/juv/_run_replace.py
@@ -1,21 +1,32 @@
 from __future__ import annotations
 
 import os
+import platform
 import signal
 import subprocess
 import sys
 
 from uv import find_uv_bin
 
+IS_WINDOWS = platform.system()
 
 def run(script: str, args: list[str]) -> None:
-    process = subprocess.Popen(  # noqa: S603
-        [os.fsdecode(find_uv_bin()), *args],
-        stdin=subprocess.PIPE,
-        stdout=sys.stdout,
-        stderr=sys.stderr,
-        preexec_fn=os.setsid,  # noqa: PLW1509
-    )
+    if not IS_WINDOWS:
+        process = subprocess.Popen(  # noqa: S603
+            [os.fsdecode(find_uv_bin()), *args],
+            stdin=subprocess.PIPE,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            preexec_fn=os.setsid,  # noqa: PLW1509
+        )
+    else:
+        process = subprocess.Popen(  # noqa: S603
+            [os.fsdecode(find_uv_bin()), *args],
+            stdin=subprocess.PIPE,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP
+        ) 
 
     assert process.stdin is not None  # noqa: S101
     process.stdin.write(script.encode())
@@ -25,6 +36,9 @@ def run(script: str, args: list[str]) -> None:
     try:
         process.wait()
     except KeyboardInterrupt:
-        os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+        if not IS_WINDOWS:
+            os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+        else:
+            os.kill(process.pid, signal.SIGTERM)
     finally:
         process.wait()

--- a/src/juv/_run_replace.py
+++ b/src/juv/_run_replace.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import os
-import platform
 import signal
 import subprocess
 import sys
 
 from uv import find_uv_bin
 
-IS_WINDOWS = platform.system()
+IS_WINDOWS = sys.platform.startswith("win")
+
 
 def run(script: str, args: list[str]) -> None:
     if not IS_WINDOWS:
@@ -25,8 +25,8 @@ def run(script: str, args: list[str]) -> None:
             stdin=subprocess.PIPE,
             stdout=sys.stdout,
             stderr=sys.stderr,
-            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP
-        ) 
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+        )
 
     assert process.stdin is not None  # noqa: S101
     process.stdin.write(script.encode())

--- a/src/juv/_run_template.py
+++ b/src/juv/_run_template.py
@@ -75,7 +75,16 @@ from platformdirs import user_data_dir
 juv_data_dir = Path(user_data_dir("juv"))
 juv_data_dir.mkdir(parents=True, exist_ok=True)
 
-temp_dir = tempfile.TemporaryDirectory(dir=juv_data_dir, ignore_cleanup_errors=True)
+# Custom TemporaryDirectory for Python < 3.10
+# TODO: Use `ignore_cleanup_errors=True` in Python 3.10+
+class TemporaryDirectoryIgnoreErrors(tempfile.TemporaryDirectory):
+    def cleanup(self):
+        try:
+            super().cleanup()
+        except Exception:
+            pass  # Ignore cleanup errors
+
+temp_dir = TemporaryDirectory(dir=juv_data_dir)
 merged_dir = Path(temp_dir.name)
 
 def handle_termination(signum, frame):

--- a/src/juv/_run_template.py
+++ b/src/juv/_run_template.py
@@ -75,7 +75,7 @@ from platformdirs import user_data_dir
 juv_data_dir = Path(user_data_dir("juv"))
 juv_data_dir.mkdir(parents=True, exist_ok=True)
 
-temp_dir = tempfile.TemporaryDirectory(dir=juv_data_dir)
+temp_dir = tempfile.TemporaryDirectory(dir=juv_data_dir, ignore_cleanup_errors=True)
 merged_dir = Path(temp_dir.name)
 
 def handle_termination(signum, frame):
@@ -129,7 +129,7 @@ if {is_managed}:
     version = importlib.metadata.version("jupyterlab")
     print("JUV_MANGED=" + "jupyterlab" + "," + version, file=sys.stderr)
 
-sys.argv = ["jupyter-lab", "{notebook}", *{args}]
+sys.argv = ["jupyter-lab", r"{notebook}", *{args}]
 main()
 """
 
@@ -148,7 +148,7 @@ if {is_managed}:
     version = importlib.metadata.version("notebook")
     print("JUV_MANGED=" + "notebook" + "," + version, file=sys.stderr)
 
-sys.argv = ["jupyter-notebook", "{notebook}", *{args}]
+sys.argv = ["jupyter-notebook", r"{notebook}", *{args}]
 main()
 """
 
@@ -167,7 +167,7 @@ if {is_managed}:
     version = importlib.metadata.version("notebook")
     print("JUV_MANGED=" + "notebook" + "," + version, file=sys.stderr)
 
-sys.argv = ["jupyter-notebook", "{notebook}", *{args}]
+sys.argv = ["jupyter-notebook", r"{notebook}", *{args}]
 main()
 """
 
@@ -187,7 +187,7 @@ if {is_managed}:
     print("JUV_MANGED=" + "nbclassic" + "," + version, file=sys.stderr)
 
 os.environ["JUPYTER_DATA_DIR"] = str(merged_dir)
-sys.argv = ["jupyter-nbclassic", "{notebook}", *{args}]
+sys.argv = ["jupyter-nbclassic", r"{notebook}", *{args}]
 main()
 """
 

--- a/tests/test_juv.py
+++ b/tests/test_juv.py
@@ -810,7 +810,9 @@ def test_stamp(
 ) -> None:
     # we need to run these tests in this folder because it uses the git history
 
-    with tempfile.TemporaryDirectory(dir=SELF_DIR) as tmpdir:
+    with tempfile.TemporaryDirectory(
+        dir=SELF_DIR, ignore_cleanup_errors=True
+    ) as tmpdir:
         tmp_path = pathlib.Path(tmpdir)
         monkeypatch.chdir(tmp_path)
 
@@ -840,7 +842,9 @@ def test_stamp_script(
 ) -> None:
     # we need to run these tests in this folder because it uses the git history
 
-    with tempfile.TemporaryDirectory(dir=SELF_DIR) as tmpdir:
+    with tempfile.TemporaryDirectory(
+        dir=SELF_DIR, ignore_cleanup_errors=True
+    ) as tmpdir:
         tmp_path = pathlib.Path(tmpdir)
         monkeypatch.chdir(tmp_path)
 
@@ -851,11 +855,11 @@ def test_stamp_script(
 # ///
 
 
-def main() -> None:                                                                                                                                                                                                               │
-    print("Hello from foo.py!")                                                                                                                                                                                                   │
-                                                                                                                                                                                                                                  │
-                                                                                                                                                                                                                                  │
-if __name__ == "__main__":                                                                                                                                                                                                        │
+def main() -> None:                                                                                                                                                                                                               |
+    print("Hello from foo.py!")                                                                                                                                                                                                   |
+                                                                                                                                                                                                                                  |
+                                                                                                                                                                                                                                  |
+if __name__ == "__main__":                                                                                                                                                                                                        |
     main()
 """)
         result = invoke(["stamp", "foo.py", "--date", "2006-01-02"])
@@ -874,11 +878,11 @@ if __name__ == "__main__":                                                      
 # ///
 
 
-def main() -> None:                                                                                                                                                                                                               │
-    print("Hello from foo.py!")                                                                                                                                                                                                   │
-                                                                                                                                                                                                                                  │
-                                                                                                                                                                                                                                  │
-if __name__ == "__main__":                                                                                                                                                                                                        │
+def main() -> None:                                                                                                                                                                                                               |
+    print("Hello from foo.py!")                                                                                                                                                                                                   |
+                                                                                                                                                                                                                                  |
+                                                                                                                                                                                                                                  |
+if __name__ == "__main__":                                                                                                                                                                                                        |
     main()
 """)
 
@@ -889,7 +893,9 @@ def test_stamp_clear(
 ) -> None:
     # we need to run these tests in this folder because it uses the git history
 
-    with tempfile.TemporaryDirectory(dir=SELF_DIR) as tmpdir:
+    with tempfile.TemporaryDirectory(
+        dir=SELF_DIR, ignore_cleanup_errors=True
+    ) as tmpdir:
         tmp_path = pathlib.Path(tmpdir)
         monkeypatch.chdir(tmp_path)
 

--- a/tests/test_juv.py
+++ b/tests/test_juv.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import os
 import pathlib
 import re
@@ -22,13 +23,11 @@ SELF_DIR = pathlib.Path(__file__).parent
 
 
 # Custom TemporaryDirectory for Python < 3.10
-# TODO: Use `ignore_cleanup_errors=True` in Python 3.10+
+# TODO: Use `ignore_cleanup_errors=True` in Python 3.10+  # noqa: TD002, TD003
 class TemporaryDirectoryIgnoreErrors(tempfile.TemporaryDirectory):
-    def cleanup(self):
-        try:
+    def cleanup(self) -> None:
+        with contextlib.suppress(Exception):
             super().cleanup()
-        except Exception:
-            pass  # Ignore cleanup errors
 
 
 def invoke(args: list[str], uv_python: str = "3.13") -> Result:

--- a/tests/test_juv.py
+++ b/tests/test_juv.py
@@ -21,6 +21,16 @@ from juv._uv import uv
 SELF_DIR = pathlib.Path(__file__).parent
 
 
+# Custom TemporaryDirectory for Python < 3.10
+# TODO: Use `ignore_cleanup_errors=True` in Python 3.10+
+class TemporaryDirectoryIgnoreErrors(tempfile.TemporaryDirectory):
+    def cleanup(self):
+        try:
+            super().cleanup()
+        except Exception:
+            pass  # Ignore cleanup errors
+
+
 def invoke(args: list[str], uv_python: str = "3.13") -> Result:
     return CliRunner().invoke(
         cli,
@@ -810,9 +820,7 @@ def test_stamp(
 ) -> None:
     # we need to run these tests in this folder because it uses the git history
 
-    with tempfile.TemporaryDirectory(
-        dir=SELF_DIR, ignore_cleanup_errors=True
-    ) as tmpdir:
+    with TemporaryDirectoryIgnoreErrors(dir=SELF_DIR) as tmpdir:
         tmp_path = pathlib.Path(tmpdir)
         monkeypatch.chdir(tmp_path)
 
@@ -842,9 +850,7 @@ def test_stamp_script(
 ) -> None:
     # we need to run these tests in this folder because it uses the git history
 
-    with tempfile.TemporaryDirectory(
-        dir=SELF_DIR, ignore_cleanup_errors=True
-    ) as tmpdir:
+    with TemporaryDirectoryIgnoreErrors(dir=SELF_DIR) as tmpdir:
         tmp_path = pathlib.Path(tmpdir)
         monkeypatch.chdir(tmp_path)
 
@@ -893,9 +899,7 @@ def test_stamp_clear(
 ) -> None:
     # we need to run these tests in this folder because it uses the git history
 
-    with tempfile.TemporaryDirectory(
-        dir=SELF_DIR, ignore_cleanup_errors=True
-    ) as tmpdir:
+    with TemporaryDirectoryIgnoreErrors(dir=SELF_DIR) as tmpdir:
         tmp_path = pathlib.Path(tmpdir)
         monkeypatch.chdir(tmp_path)
 


### PR DESCRIPTION
I only had to make a few code tweaks to get the code working on my windows box for firing up the subprocess, and I added raw string syntax for the notebook path in case the notebook's path has a \t in it so it doesnt change the \t into a tab. or a \u into a unicode escape etc.  and I added `ignore_cleanup_errors=True` to all the tempdirectory usage because without it, an error would throw anytime I shutdown jupyterlab because the nbsignatures.db of jupyter was locked.

To get the tests to pass I had to replace the pipes at the end of some of the lines with the pipe symbol from my keyboard (I'm not going to pretend to be an encoding expert, but when I did a find/replace on the pipe symbols in the existing code with the pipe symbol on my keyboard, magically the tests passed for me)

let me know what you think!