### PR TITLE
Add experimental VS Code (`code`) runtime to `juv run`

### DIFF
--- a/src/juv/_run.py
+++ b/src/juv/_run.py
@@ -83,7 +83,7 @@ def run(  # noqa: PLR0913
     if mode == "dry":
         print(f"uv {' '.join(args)}")  # noqa: T201
 
-    elif mode == "managed":
+    elif mode == "managed" and runtime.name != "code":
         from ._run_managed import run as run_managed
 
         run_managed(script, args, str(path))


### PR DESCRIPTION
This PR adds a `code` runtime option to `juv run`, allowing VS Code to be launched in a way similar to other Jupyter runtimes. 

```sh
juv run --jupyter=code example.ipynb
# or 
# JUV_RUNTIME=code juv run example.ipynb
```


The approach uses the behavior of the `code` CLI, which inherits the environment it was run in.

A script is created using the inline metadata so that running `code <notebook.ipynb>` ensures a virtual environment is available in the VS Code session with the necessary dependencies.

Ideally, we'd have a VS Code extension to dynamically create and register virtual environments for better discoverability. This implementation goes the other way by enabling basic support via the CLI. However, the user must manually select the virtual environment from VS Code's dropdown, where it appears with an obscure, temporary name (derived from the hashed environment created by `uv`).
