### PR TITLE
Sync lockfile during `remove` command

### DIFF
--- a/tests/test_juv.py
+++ b/tests/test_juv.py
@@ -1110,3 +1110,49 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/4d/3b371736693c952b616dac469d91fb9a42217758bf0f79ac4170c032069d/polars-0.16.1-cp37-abi3-win_amd64.whl", hash = "sha256:a670586eee6fad98a2daafbe3f6dfc845b35a22e44bc4daaca93d4f0f4d05229", size = 16264469 },
 ]
 """)
+
+
+def test_remove_updates_lock(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    invoke(["init", "test.ipynb"])
+    invoke(["add", "test.ipynb", "polars"])
+    result = invoke(["lock", "test.ipynb"])
+    assert result.exit_code == 0
+    assert result.stdout == snapshot("Locked `test.ipynb`\n")
+    assert jupytext.read(tmp_path / "test.ipynb").metadata["uv.lock"] == snapshot("""\
+version = 1
+requires-python = ">=3.13"
+
+[options]
+exclude-newer = "2023-02-01T02:00:00Z"
+
+[manifest]
+requirements = [{ name = "polars" }]
+
+[[package]]
+name = "polars"
+version = "0.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/e34f5677393a986b5a6b0b8284da31154bdf0ed55a1feffc73cc8c0dfa4e/polars-0.16.1.tar.gz", hash = "sha256:ebba7a51581084adb85dde10579b1dd8b648f7c5ca38a6839eee64d2e4827612", size = 1352066 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/aa/ecf2df7468dab00f8ad7b5fdcd834ca4bffee8e6095e011153c9d82d5df0/polars-0.16.1-cp37-abi3-macosx_10_7_x86_64.whl", hash = "sha256:180172c8db33f950b3f2ff7793d2cf3de9d3ad9b13c5f0181cda0ac3e7db5977", size = 14844819 },
+    { url = "https://files.pythonhosted.org/packages/f2/c5/f19a2b3f1d3251615ee136fb03f251eb00e4566688afa3b84f0d1cb4f4d3/polars-0.16.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:6c391546a158233172589ce810fcafd71a60d776add8421364bdd5ff05af2cd9", size = 12930182 },
+    { url = "https://files.pythonhosted.org/packages/32/bc/5f674384f48dfad969a634918487dc0b207ee08702d57433d24d0da6a3fb/polars-0.16.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2096a1384a5fecf003bb3915264212c63d1c43e8790126ee8fcdd682f1782ac", size = 13382356 },
+    { url = "https://files.pythonhosted.org/packages/7e/82/ee89b63d8cd638d12b79515fb0c63d602ca8fc5eb8d1c4b6b9f690a1a02d/polars-0.16.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:934bca853a0086a30800c40ac615578894531b378afc1ba4c1a7e15855218c64", size = 15291186 },
+    { url = "https://files.pythonhosted.org/packages/d8/4d/3b371736693c952b616dac469d91fb9a42217758bf0f79ac4170c032069d/polars-0.16.1-cp37-abi3-win_amd64.whl", hash = "sha256:a670586eee6fad98a2daafbe3f6dfc845b35a22e44bc4daaca93d4f0f4d05229", size = 16264469 },
+]
+""")
+
+    invoke(["remove", "test.ipynb", "polars"])
+    assert result.exit_code == 0
+    assert jupytext.read(tmp_path / "test.ipynb").metadata["uv.lock"] == snapshot("""\
+version = 1
+requires-python = ">=3.13"
+
+[options]
+exclude-newer = "2023-02-01T02:00:00Z"
+""")


### PR DESCRIPTION
If a notebook is locked (e.g., via `juv lock Untitled.ipynb`), the
`remove` command now updates the existing lockfile to ensure
consistency.
