### PR TITLE
Respect lockfile in `run`

### DIFF
--- a/src/juv/_run.py
+++ b/src/juv/_run.py
@@ -87,7 +87,7 @@ def run(  # noqa: PLR0913
     elif mode == "managed":
         from ._run_managed import run as run_managed
 
-        run_managed(script, args, str(path))
+        run_managed(script, args, str(path), lockfile_contents)
     else:
         from ._run_replace import run as run_replace
 

--- a/src/juv/_run.py
+++ b/src/juv/_run.py
@@ -56,6 +56,7 @@ def run(  # noqa: PLR0913
     """Launch a notebook or script."""
     runtime = Runtime.try_from_specifier(jupyter)
     meta, nb = to_notebook(path)
+    lockfile_contents = nb.get("metadata", {}).get("uv.lock")
 
     if path.suffix == ".py":
         path = path.with_suffix(".ipynb")
@@ -90,4 +91,4 @@ def run(  # noqa: PLR0913
     else:
         from ._run_replace import run as run_replace
 
-        run_replace(script, args)
+        run_replace(script, args, lockfile_contents)

--- a/src/juv/_run_replace.py
+++ b/src/juv/_run_replace.py
@@ -28,6 +28,9 @@ def run(script: str, args: list[str], lockfile_contents: str | None) -> None:
         if lockfile_contents:
             # Write the contents so UV picks it up
             lockfile.write_text(lockfile_contents)
+            # Forward path to underlying process.
+            # We rewrite the lockfile entry (if necessary) within that process.
+            env["JUV_LOCKFILE_PATH"] = str(lockfile)
 
         if not IS_WINDOWS:
             process = subprocess.Popen(  # noqa: S603

--- a/src/juv/_run_replace.py
+++ b/src/juv/_run_replace.py
@@ -4,41 +4,50 @@ import os
 import signal
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
 
 from uv import find_uv_bin
 
 IS_WINDOWS = sys.platform.startswith("win")
 
 
-def run(script: str, args: list[str]) -> None:
-    if not IS_WINDOWS:
-        process = subprocess.Popen(  # noqa: S603
-            [os.fsdecode(find_uv_bin()), *args],
-            stdin=subprocess.PIPE,
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-            preexec_fn=os.setsid,  # noqa: PLW1509
-        )
-    else:
-        process = subprocess.Popen(  # noqa: S603
-            [os.fsdecode(find_uv_bin()), *args],
-            stdin=subprocess.PIPE,
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
-        )
+def run(script: str, args: list[str], lockfile_contents: str | None) -> None:
+    with tempfile.NamedTemporaryFile(
+        mode="w+",
+        delete=True,
+        suffix=".py",
+        encoding="utf-8",
+    ) as f:
+        lockfile = Path(f"{f.name}.lock")
+        f.write(script)
+        f.flush()
 
-    assert process.stdin is not None  # noqa: S101
-    process.stdin.write(script.encode())
-    process.stdin.flush()
-    process.stdin.close()
+        if lockfile_contents:
+            lockfile.write_text(lockfile_contents)
 
-    try:
-        process.wait()
-    except KeyboardInterrupt:
         if not IS_WINDOWS:
-            os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+            process = subprocess.Popen(  # noqa: S603
+                [os.fsdecode(find_uv_bin()), *args, f.name],
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+                preexec_fn=os.setsid,  # noqa: PLW1509
+            )
         else:
-            os.kill(process.pid, signal.SIGTERM)
-    finally:
-        process.wait()
+            process = subprocess.Popen(  # noqa: S603
+                [os.fsdecode(find_uv_bin()), *args, f.name],
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+            )
+
+        try:
+            process.wait()
+        except KeyboardInterrupt:
+            if not IS_WINDOWS:
+                os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+            else:
+                os.kill(process.pid, signal.SIGTERM)
+        finally:
+            lockfile.unlink(missing_ok=True)
+            process.wait()

--- a/src/juv/_run_replace.py
+++ b/src/juv/_run_replace.py
@@ -23,7 +23,10 @@ def run(script: str, args: list[str], lockfile_contents: str | None) -> None:
         f.write(script)
         f.flush()
 
+        env = os.environ.copy()
+
         if lockfile_contents:
+            # Write the contents so UV picks it up
             lockfile.write_text(lockfile_contents)
 
         if not IS_WINDOWS:
@@ -32,6 +35,7 @@ def run(script: str, args: list[str], lockfile_contents: str | None) -> None:
                 stdout=sys.stdout,
                 stderr=sys.stderr,
                 preexec_fn=os.setsid,  # noqa: PLW1509
+                env=env,
             )
         else:
             process = subprocess.Popen(  # noqa: S603
@@ -39,6 +43,7 @@ def run(script: str, args: list[str], lockfile_contents: str | None) -> None:
                 stdout=sys.stdout,
                 stderr=sys.stderr,
                 creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+                env=env,
             )
 
         try:

--- a/src/juv/_run_template.py
+++ b/src/juv/_run_template.py
@@ -225,6 +225,5 @@ def prepare_run_script_and_uv_run_args(  # noqa: PLR0913
         *([f"--python={python}"] if python else []),
         f"--with={runtime.as_with_arg()}",
         *(["--with=" + ",".join(with_args)] if with_args else []),
-        "-",
     ]
     return script, args

--- a/src/juv/_run_template.py
+++ b/src/juv/_run_template.py
@@ -225,5 +225,6 @@ def prepare_run_script_and_uv_run_args(  # noqa: PLR0913
         *([f"--python={python}"] if python else []),
         f"--with={runtime.as_with_arg()}",
         *(["--with=" + ",".join(with_args)] if with_args else []),
+        "--script",
     ]
     return script, args

--- a/src/juv/_run_template.py
+++ b/src/juv/_run_template.py
@@ -63,6 +63,32 @@ class Runtime:
         return with_
 
 
+UPDATE_LOCKFILE = """
+import json
+import os
+
+def update_uv_lock(notebook_path: str):
+    lockfile_path = os.environ.get("JUV_LOCKFILE_PATH")
+
+    if not lockfile_path:
+        return
+
+    with open(lockfile_path, "r", encoding="utf-8") as lockfile:
+        lock_contents = lockfile.read()
+
+    with open(notebook_path, "r", encoding="utf-8") as f:
+        nb = json.load(f)
+
+    # Replace contents and rewrite notebook file before opening
+    nb.setdefault("metadata", {{}})["uv.lock"] = lock_contents
+    with open(notebook_path, "w", encoding="utf-8") as f:
+        json.dump(nb, f, ensure_ascii=False, indent=1)
+        f.write("\\n")
+
+update_uv_lock(r"{notebook}")
+"""
+
+
 SETUP_JUPYTER_DATA_DIR = """
 import tempfile
 import signal
@@ -130,6 +156,7 @@ import sys
 
 from jupyterlab.labapp import main
 
+{UPDATE_LOCKFILE}
 {SETUP_JUPYTER_DATA_DIR}
 
 if {is_managed}:
@@ -149,6 +176,7 @@ import sys
 
 from notebook.app import main
 
+{UPDATE_LOCKFILE}
 {SETUP_JUPYTER_DATA_DIR}
 
 if {is_managed}:
@@ -168,6 +196,7 @@ import sys
 
 from notebook.notebookapp import main
 
+{UPDATE_LOCKFILE}
 {SETUP_JUPYTER_DATA_DIR}
 
 if {is_managed}:
@@ -187,6 +216,7 @@ import sys
 
 from nbclassic.notebookapp import main
 
+{UPDATE_LOCKFILE}
 {SETUP_JUPYTER_DATA_DIR}
 
 if {is_managed}:
@@ -195,7 +225,6 @@ if {is_managed}:
     version = importlib.metadata.version("nbclassic")
     print("JUV_MANGED=" + "nbclassic" + "," + version, file=sys.stderr)
 
-os.environ["JUPYTER_DATA_DIR"] = str(merged_dir)
 sys.argv = ["jupyter-nbclassic", r"{notebook}", *{args}]
 main()
 """
@@ -217,6 +246,7 @@ def prepare_run_script_and_uv_run_args(  # noqa: PLR0913
         notebook=target,
         args=jupyter_args,
         SETUP_JUPYTER_DATA_DIR=SETUP_JUPYTER_DATA_DIR,
+        UPDATE_LOCKFILE=UPDATE_LOCKFILE.format(notebook=target),
         is_managed=mode == "managed",
     )
     args = [

--- a/tests/test_juv.py
+++ b/tests/test_juv.py
@@ -180,7 +180,7 @@ def test_run_basic(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> N
     invoke(["init", "test.ipynb"])
     result = invoke(["run", "test.ipynb"])
     assert result.exit_code == 0
-    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab -\n")
+    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab\n")
 
 
 def test_run_python_override(
@@ -192,7 +192,7 @@ def test_run_python_override(
     result = invoke(["run", "--python=3.12", "test.ipynb"])
     assert result.exit_code == 0
     assert result.stdout == snapshot(
-        "uv run --no-project --python=3.12 --with=jupyterlab -\n"
+        "uv run --no-project --python=3.12 --with=jupyterlab\n"
     )
 
 
@@ -203,7 +203,7 @@ def test_run_with_script_meta(
     invoke(["init", "test.ipynb", "--with", "numpy"])
     result = invoke(["run", "test.ipynb"])
     assert result.exit_code == 0
-    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab -\n")
+    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab\n")
 
 
 def test_run_with_script_meta_and_with_args(
@@ -214,7 +214,7 @@ def test_run_with_script_meta_and_with_args(
     result = invoke(["run", "--with", "polars", "--with=anywidget,foo", "test.ipynb"])
     assert result.exit_code == 0
     assert result.stdout == snapshot(
-        "uv run --no-project --with=jupyterlab --with=polars,anywidget,foo -\n"
+        "uv run --no-project --with=jupyterlab --with=polars,anywidget,foo\n"
     )
 
 
@@ -224,7 +224,7 @@ def test_run_nbclassic(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) 
     result = invoke(["run", "--with=polars", "--jupyter=nbclassic", "test.ipynb"])
     assert result.exit_code == 0
     assert result.stdout == snapshot(
-        "uv run --no-project --with=nbclassic --with=polars -\n"
+        "uv run --no-project --with=nbclassic --with=polars\n"
     )
 
 
@@ -236,7 +236,7 @@ def test_run_notebook_and_version(
     result = invoke(["run", "--jupyter=notebook@6.4.0", "test.ipynb"])
     assert result.exit_code == 0
     assert result.stdout == snapshot(
-        "uv run --no-project --with=notebook==6.4.0,setuptools -\n"
+        "uv run --no-project --with=notebook==6.4.0,setuptools\n"
     )
 
 
@@ -256,7 +256,7 @@ def test_run_with_extra_jupyter_flags(
         ]
     )
     assert result.exit_code == 0
-    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab -\n")
+    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab\n")
 
 
 def test_run_uses_version_specifier(
@@ -282,7 +282,7 @@ print('Hello, world!')
 
     result = invoke(["run", "script.ipynb"])
     assert result.exit_code == 0
-    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab -\n")
+    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab\n")
 
 
 def filter_tempfile_ipynb(output: str) -> str:

--- a/tests/test_juv.py
+++ b/tests/test_juv.py
@@ -180,7 +180,7 @@ def test_run_basic(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> N
     invoke(["init", "test.ipynb"])
     result = invoke(["run", "test.ipynb"])
     assert result.exit_code == 0
-    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab\n")
+    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab --script\n")
 
 
 def test_run_python_override(
@@ -192,7 +192,7 @@ def test_run_python_override(
     result = invoke(["run", "--python=3.12", "test.ipynb"])
     assert result.exit_code == 0
     assert result.stdout == snapshot(
-        "uv run --no-project --python=3.12 --with=jupyterlab\n"
+        "uv run --no-project --python=3.12 --with=jupyterlab --script\n"
     )
 
 
@@ -203,7 +203,7 @@ def test_run_with_script_meta(
     invoke(["init", "test.ipynb", "--with", "numpy"])
     result = invoke(["run", "test.ipynb"])
     assert result.exit_code == 0
-    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab\n")
+    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab --script\n")
 
 
 def test_run_with_script_meta_and_with_args(
@@ -214,7 +214,7 @@ def test_run_with_script_meta_and_with_args(
     result = invoke(["run", "--with", "polars", "--with=anywidget,foo", "test.ipynb"])
     assert result.exit_code == 0
     assert result.stdout == snapshot(
-        "uv run --no-project --with=jupyterlab --with=polars,anywidget,foo\n"
+        "uv run --no-project --with=jupyterlab --with=polars,anywidget,foo --script\n"
     )
 
 
@@ -224,7 +224,7 @@ def test_run_nbclassic(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) 
     result = invoke(["run", "--with=polars", "--jupyter=nbclassic", "test.ipynb"])
     assert result.exit_code == 0
     assert result.stdout == snapshot(
-        "uv run --no-project --with=nbclassic --with=polars\n"
+        "uv run --no-project --with=nbclassic --with=polars --script\n"
     )
 
 
@@ -236,7 +236,7 @@ def test_run_notebook_and_version(
     result = invoke(["run", "--jupyter=notebook@6.4.0", "test.ipynb"])
     assert result.exit_code == 0
     assert result.stdout == snapshot(
-        "uv run --no-project --with=notebook==6.4.0,setuptools\n"
+        "uv run --no-project --with=notebook==6.4.0,setuptools --script\n"
     )
 
 
@@ -256,7 +256,7 @@ def test_run_with_extra_jupyter_flags(
         ]
     )
     assert result.exit_code == 0
-    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab\n")
+    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab --script\n")
 
 
 def test_run_uses_version_specifier(
@@ -282,7 +282,7 @@ print('Hello, world!')
 
     result = invoke(["run", "script.ipynb"])
     assert result.exit_code == 0
-    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab\n")
+    assert result.stdout == snapshot("uv run --no-project --with=jupyterlab --script\n")
 
 
 def filter_tempfile_ipynb(output: str) -> str:


### PR DESCRIPTION
See

- #64 
- #65 
- #66 

The `run` command now detects the presence of a lockfile and will run the notebook in a locked enviroment.


TODO:

- [x] Have `run` sync the lockfile
- [x] Update managed version to use lockfile
