### PR TITLE
Add `tree` command to list notebook dependencies

### DIFF
--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -477,6 +477,18 @@ def lock(
         sys.exit(1)
 
 
+@cli.command()
+@click.argument("file", type=click.Path(exists=True), required=True)
+def tree(
+    *,
+    file: str,
+) -> None:
+    """Display the notebook's dependency tree."""
+    from ._tree import tree
+
+    tree(path=Path(file))
+
+
 def main() -> None:
     """Run the CLI."""
     upgrade_legacy_jupyter_command(sys.argv)

--- a/src/juv/_add.py
+++ b/src/juv/_add.py
@@ -141,7 +141,7 @@ def add_notebook(  # noqa: PLR0913
         cell["source"] = f.read().strip()
 
         if lockfile.exists():
-            notebook["metadata"]["uv.lock"] = lockfile.read_text()
+            notebook["metadata"]["uv.lock"] = lockfile.read_text(encoding="utf-8")
             lockfile.unlink(missing_ok=True)
 
     write_ipynb(notebook, path.with_suffix(".ipynb"))

--- a/src/juv/_remove.py
+++ b/src/juv/_remove.py
@@ -58,7 +58,7 @@ def remove(
         cell["source"] = f.read().strip()
 
         if lockfile.exists():
-            notebook["metadata"]["uv.lock"] = lockfile.read_text()
+            notebook["metadata"]["uv.lock"] = lockfile.read_text(encoding="utf-8")
             lockfile.unlink(missing_ok=True)
 
     write_ipynb(notebook, path.with_suffix(".ipynb"))

--- a/src/juv/_tree.py
+++ b/src/juv/_tree.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import jupytext
 
-from ._nbutils import code_cell
+from ._nbutils import code_cell, write_ipynb
 from ._pep723 import includes_inline_metadata
 from ._utils import find
 from ._uv import uv
@@ -50,4 +50,5 @@ def tree(
 
         if lockfile.exists():
             notebook.metadata["uv.lock"] = lockfile.read_text(encoding="utf-8")
+            write_ipynb(notebook, path)
             lockfile.unlink(missing_ok=True)

--- a/src/juv/_tree.py
+++ b/src/juv/_tree.py
@@ -1,19 +1,22 @@
+import sys
 import tempfile
 from pathlib import Path
 
 import jupytext
 
-from ._nbutils import code_cell, write_ipynb
+from ._nbutils import code_cell
 from ._pep723 import includes_inline_metadata
 from ._utils import find
 from ._uv import uv
 
 
-def lock(
+def tree(
     path: Path,
 ) -> None:
     notebook = jupytext.read(path, fmt="ipynb")
+    lockfile_contents = notebook.get("metadata", {}).get("uv.lock")
 
+    # need a reference so we can modify the cell["source"]
     cell = find(
         lambda cell: (
             cell["cell_type"] == "code"
@@ -32,16 +35,19 @@ def lock(
         suffix=".py",
         dir=path.parent,
         encoding="utf-8",
-    ) as temp_file:
-        temp_file.write(cell["source"].strip())
-        temp_file.flush()
+    ) as f:
+        lockfile = Path(f"{f.name}.lock")
 
-        uv(["lock", "--script", temp_file.name], check=True)
+        f.write(cell["source"].strip())
+        f.flush()
 
-        lock_file = Path(f"{temp_file.name}.lock")
+        if lockfile_contents:
+            lockfile.write_text(lockfile_contents)
 
-        notebook["metadata"]["uv.lock"] = lock_file.read_text(encoding="utf-8")
+        result = uv(["tree", "--script", f.name], check=True)
 
-        lock_file.unlink(missing_ok=True)
+        sys.stdout.write(result.stdout.decode("utf-8"))
 
-    write_ipynb(notebook, path.with_suffix(".ipynb"))
+        if lockfile.exists():
+            notebook.metadata["uv.lock"] = lockfile.read_text(encoding="utf-8")
+            lockfile.unlink(missing_ok=True)

--- a/src/juv/_uv.py
+++ b/src/juv/_uv.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 
 from uv import find_uv_bin
 

--- a/src/juv/_uv.py
+++ b/src/juv/_uv.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import sys
 
 from uv import find_uv_bin
 

--- a/tests/test_juv.py
+++ b/tests/test_juv.py
@@ -1156,3 +1156,21 @@ requires-python = ">=3.13"
 [options]
 exclude-newer = "2023-02-01T02:00:00Z"
 """)
+
+
+def test_tree(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    invoke(["init", "test.ipynb"])
+    invoke(["add", "test.ipynb", "rich"])
+    result = invoke(["tree", "test.ipynb"])
+    assert result.exit_code == 0
+    assert result.stdout == snapshot("""\
+rich v13.3.1
+├── markdown-it-py v2.1.0
+│   └── mdurl v0.1.2
+└── pygments v2.14.0
+""")

--- a/tests/test_juv.py
+++ b/tests/test_juv.py
@@ -1174,3 +1174,50 @@ rich v13.3.1
 │   └── mdurl v0.1.2
 └── pygments v2.14.0
 """)
+
+
+def test_tree_updates_lock(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    invoke(["init", "test.ipynb"])
+    invoke(["lock", "test.ipynb"])
+    invoke(["add", "test.ipynb", "attrs"])
+    invoke(["tree", "test.ipynb"])
+    notebook = jupytext.read(tmp_path / "test.ipynb")
+    assert notebook.metadata["uv.lock"] == snapshot("""\
+version = 1
+requires-python = ">=3.13"
+
+[options]
+exclude-newer = "2023-02-01T02:00:00Z"
+
+[manifest]
+requirements = [{ name = "attrs", specifier = ">=22.2.0" }]
+
+[[package]]
+name = "attrs"
+version = "22.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/31/3f468da74c7de4fcf9b25591e682856389b3400b4b62f201e65f15ea3e07/attrs-22.2.0.tar.gz", hash = "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99", size = 215900 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/6e/6f83bf616d2becdf333a1640f1d463fef3150e2e926b7010cb0f81c95e88/attrs-22.2.0-py3-none-any.whl", hash = "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836", size = 60018 },
+]
+""")
+
+    notebook.cells[0] = new_code_cell("""# /// script
+# dependencies = []
+# requires-python = ">=3.8"
+# ///
+""")
+    write_ipynb(notebook, tmp_path / "test.ipynb")
+    invoke(["tree", "test.ipynb"])
+    assert jupytext.read(tmp_path / "test.ipynb").metadata["uv.lock"] == snapshot("""\
+version = 1
+requires-python = ">=3.8"
+
+[options]
+exclude-newer = "2023-02-01T02:00:00Z"
+""")


### PR DESCRIPTION
Show notebook dependencies as a tree:

```sh
juv init
juv add Untitled.ipynb anywidget
juv tree Untitled.ipynb
# anywidget v0.9.13
# ├── ipywidgets v8.1.5
# │   ├── comm v0.2.2
# │   │   └── traitlets v5.14.3
# │   ├── ipython v8.31.0
# │   │   ├── decorator v5.1.1
# │   │   ├── jedi v0.19.2
# │   │   │   └── parso v0.8.4
# │   │   ├── matplotlib-inline v0.1.7
# │   │   │   └── traitlets v5.14.3
# │   │   ├── pexpect v4.9.0
# │   │   │   └── ptyprocess v0.7.0
# │   │   ├── prompt-toolkit v3.0.48
# │   │   │   └── wcwidth v0.2.13
# │   │   ├── pygments v2.19.1
# │   │   ├── stack-data v0.6.3
# │   │   │   ├── asttokens v3.0.0
# │   │   │   ├── executing v2.1.0
# │   │   │   └── pure-eval v0.2.3
# │   │   └── traitlets v5.14.3
# │   ├── jupyterlab-widgets v3.0.13
# │   ├── traitlets v5.14.3
# │   └── widgetsnbextension v4.0.13
# ├── psygnal v0.11.1
# └── typing-extensions v4.12.2

```
