### PR TITLE
Add `--clear` flag to `lock` to clear lockfile metadata

### DIFF
--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -461,17 +461,22 @@ def remove(
 
 @cli.command()
 @click.argument("file", type=click.Path(exists=True), required=True)
+@click.option("--clear", is_flag=True, help="Clear the lockfile contents.")
 def lock(
     *,
     file: str,
+    clear: bool,
 ) -> None:
     """Update the notebooks's lockfile."""
     from ._lock import lock
 
     try:
-        lock(path=Path(file))
+        lock(path=Path(file), clear=clear)
         path = os.path.relpath(Path(file).resolve(), Path.cwd())
-        rich.print(f"Locked `[cyan]{path}[/cyan]`")
+        if clear:
+            rich.print(f"Cleared lockfile `[cyan]{path}[/cyan]`")
+        else:
+            rich.print(f"Locked `[cyan]{path}[/cyan]`")
     except RuntimeError as e:
         rich.print(e, file=sys.stderr)
         sys.exit(1)

--- a/src/juv/_lock.py
+++ b/src/juv/_lock.py
@@ -9,10 +9,13 @@ from ._utils import find
 from ._uv import uv
 
 
-def lock(
-    path: Path,
-) -> None:
+def lock(*, path: Path, clear: bool) -> None:
     notebook = jupytext.read(path, fmt="ipynb")
+
+    if clear:
+        notebook.get("metadata", {}).pop("uv.lock", None)
+        write_ipynb(notebook, path)
+        return
 
     cell = find(
         lambda cell: (


### PR DESCRIPTION
Clears lockfile metadata from the Jupyter notebook with the addition of
the `--clear` to the command.
