### PR TITLE
Add `juv venv` to support exporting explicit notebook enviroments

### DIFF
--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -522,6 +522,50 @@ def export(
     export(path=Path(file))
 
 
+@cli.command()
+@click.option(
+    "--from",
+    "from_",
+    type=click.Path(exists=True),
+    required=True,
+    help="The notebook from which to derive the virtual environment.",
+)
+@click.option(
+    "--python",
+    "-p",
+    type=click.STRING,
+    required=False,
+    help="The Python interpreter to use to determine the minimum supported Python version. [env: UV_PYTHON=]",  # noqa: E501
+)
+@click.option(
+    "--seed", is_flag=True, help="Install `ipykernel` into the virtual environment."
+)
+@click.argument(
+    "path",
+    required=False,
+)
+def venv(
+    *,
+    from_: str,
+    python: str | None,
+    seed: bool,
+    path: str | None,
+) -> None:
+    """Create a virtual enviroment from a notebook."""
+    from ._venv import venv
+
+    try:
+        venv(
+            source=Path(from_),
+            python=python,
+            path=Path(path) if path else None,
+            seed=seed,
+        )
+    except RuntimeError as e:
+        rich.print(e, file=sys.stderr)
+        sys.exit(1)
+
+
 def main() -> None:
     """Run the CLI."""
     upgrade_legacy_jupyter_command(sys.argv)

--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -538,7 +538,7 @@ def export(
     help="The Python interpreter to use to determine the minimum supported Python version. [env: UV_PYTHON=]",  # noqa: E501
 )
 @click.option(
-    "--seed", is_flag=True, help="Install `ipykernel` into the virtual environment."
+    "--no-kernel", is_flag=True, help="Exclude `ipykernel` from the enviroment."
 )
 @click.argument(
     "path",
@@ -548,7 +548,7 @@ def venv(
     *,
     from_: str,
     python: str | None,
-    seed: bool,
+    no_kernel: bool,
     path: str | None,
 ) -> None:
     """Create a virtual enviroment from a notebook."""
@@ -559,7 +559,7 @@ def venv(
             source=Path(from_),
             python=python,
             path=Path(path) if path else None,
-            seed=seed,
+            no_kernel=no_kernel,
         )
     except RuntimeError as e:
         rich.print(e, file=sys.stderr)

--- a/src/juv/_init.py
+++ b/src/juv/_init.py
@@ -62,7 +62,7 @@ def get_first_non_conflicting_untitled_ipynb(directory: Path) -> Path:
 def init(
     path: Path | None,
     python: str | None,
-    packages: typing.Sequence[str] = [],
+    packages: typing.Sequence[str] | None = None,
 ) -> Path:
     """Initialize a new notebook.
 
@@ -81,6 +81,7 @@ def init(
         The path to the new notebook.
 
     """
+    packages = packages or []
     if not path:
         path = get_first_non_conflicting_untitled_ipynb(Path.cwd())
 

--- a/src/juv/_uv.py
+++ b/src/juv/_uv.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 
 from uv import find_uv_bin
 
@@ -25,3 +26,43 @@ def uv(args: list[str], *, check: bool) -> subprocess.CompletedProcess:
     """
     uv = os.fsdecode(find_uv_bin())
     return subprocess.run([uv, *args], capture_output=True, check=check, env=os.environ)  # noqa: S603
+
+
+def uv_piped(
+    args: list[str],
+    *,
+    check: bool,
+    env: dict | None = None,
+    input: bytes | None = None,  # noqa: A002
+) -> subprocess.CompletedProcess:
+    """Invoke a uv subprocess and stream the output to the console.
+
+    Parameters
+    ----------
+    args : list[str]
+        The arguments to pass to the subprocess.
+
+    check : bool
+        Whether to raise an exception if the subprocess returns a non-zero exit code.
+
+    env : dict | None
+        The system enviroment to run the subprocess.
+
+    input : bytes | None
+        Contents to forwads as input to the subprocess.
+
+    Returns
+    -------
+    subprocess.CompletedProcess
+        The result of the subprocess.
+
+    """
+    uv = os.fsdecode(find_uv_bin())
+    return subprocess.run(  # noqa: S603
+        [uv, *args],
+        check=check,
+        env=env or os.environ,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        input=input,
+    )

--- a/src/juv/_venv.py
+++ b/src/juv/_venv.py
@@ -16,7 +16,7 @@ def venv(
     source: pathlib.Path,
     python: str | None,
     path: pathlib.Path | None,
-    seed: bool,
+    no_kernel: bool,
 ) -> None:
     uv_piped(
         [
@@ -28,7 +28,7 @@ def venv(
     )
 
     locked_requirements = export_to_string(source)
-    if seed:
+    if not no_kernel:
         locked_requirements += "ipykernel\n"
 
     env = os.environ.copy()

--- a/src/juv/_venv.py
+++ b/src/juv/_venv.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+import typing
+
+from juv._uv import uv_piped
+
+from ._export import export_to_string
+
+if typing.TYPE_CHECKING:
+    import pathlib
+
+
+def venv(
+    *,
+    source: pathlib.Path,
+    python: str | None,
+    path: pathlib.Path | None,
+    seed: bool,
+) -> None:
+    uv_piped(
+        [
+            "venv",
+            *(["--python", python] if python else []),
+            *([str(path)] if path else []),
+        ],
+        check=True,
+    )
+
+    locked_requirements = export_to_string(source)
+    if seed:
+        locked_requirements += "ipykernel\n"
+
+    env = os.environ.copy()
+    if path:
+        env["VIRTUAL_ENV"] = str(path)
+
+    uv_piped(
+        ["pip", "install", "-r", "-"],
+        env=env,
+        input=locked_requirements.encode("utf-8"),
+        check=True,
+    )


### PR DESCRIPTION
Alternative to #62 

Some editors and enviroments are missing the benefits from `juv` standalone notebooks, simply because we don't make it easy to _use_ the specified virutal enviroment outside of spawning a Jupyter runtime with `juv run`.

While we typically try to hide virtual environments, they remain crucial for ecosystem like language servers, autocomplete, and intellisense, and exposing some way to quickly make a notebok enviroment is the easiest way to bring `juv` standalone notebooks to unknown tools.

To improve compatibility with more editors and tools, this PR introduces:

```sh
juv venv --from=Untitled.ipynb
```

This command creates a virtual environment with the dependencies and locking behavior expected from `juv`, and adds `ipykernel` for running the notebook. The resulting environment can be selected in an editor like VS Code.

To create a venv with only the locked dependencies, add the `--no-kernel` flag:

```sh
juv venv --from=Untitled.ipynb --no-kernel
```

### Alternatives

While editor-specific integrations for `juv` would be ideal (and still welcome!), they require significant effort. I anticipate there will be opportunities to piggyback on whatever editors do to support uv standalone scripts in the future.

In the meantime, this approach provides a decent escape hatch. I think it's a reasonable tradeoff for individuals that want to use their favorite editor with notebook support and also read/write standalone notebooks.

### Note

It's worth noting that these commands are basically sugar for composing some lesser known `juv` and `uv` commands:

```sh
uv env
juv export Untitled.ipynb | uv pip install -r -
```

or, when including `ipykernel`:

```sh
uv env
(juv export Untitled.ipynb; echo ipykernel) | uv pip install -r -
```

However, I think having a simple high-level API is ideal. It also means one does not need to have `uv` installed (even though they should!)
