### PR TITLE
Extend venv export to standalone scripts as well

### DIFF
--- a/src/juv/__init__.py
+++ b/src/juv/__init__.py
@@ -528,7 +528,7 @@ def export(
     "from_",
     type=click.Path(exists=True),
     required=True,
-    help="The notebook from which to derive the virtual environment.",
+    help="The notebook or script from which to derive the virtual environment.",
 )
 @click.option(
     "--python",

--- a/src/juv/_venv.py
+++ b/src/juv/_venv.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import typing
 
-from juv._uv import uv_piped
+from juv._uv import uv, uv_piped
 
 from ._export import export_to_string
 
@@ -27,9 +27,14 @@ def venv(
         check=True,
     )
 
-    locked_requirements = export_to_string(source)
-    if not no_kernel:
-        locked_requirements += "ipykernel\n"
+    if source.suffix == ".py":
+        # just defer to uv behavior
+        result = uv(["export", "--script", str(source)], check=True)
+        locked_requirements = result.stdout.decode("utf-8")
+    else:
+        locked_requirements = export_to_string(source)
+        if not no_kernel:
+            locked_requirements += "ipykernel\n"
 
     env = os.environ.copy()
     if path:


### PR DESCRIPTION
Allows for passing a script with inline script metadata to `juv venv`.

```sh
uv init --script foo.py
uv add --script foo.py attrs
juv venv --from=foo.py
# Using CPython 3.13.0
# Creating virtual environment at: .venv
# Activate with: source .venv/bin/activate
# Using Python 3.13.0 environment at: .venv
# Resolved 1 package in 0.62ms
# Installed 1 package in 1ms
# + attrs==25.1.0
```

Useful for quickly creating a `.venv` for a standalone script, which can be
used by other tools like text editors or IDEs.
