### PR TITLE
 Correctly resolve Jupyter data/config dirs on Windows

### DIFF
--- a/src/juv/static/setup.py
+++ b/src/juv/static/setup.py
@@ -1,42 +1,11 @@
 import contextlib  # noqa: D100, INP001
 import json
 import os
-import signal
 import sys
-import tempfile
 from pathlib import Path
 
-from platformdirs import user_data_dir
 
-
-# Custom TemporaryDirectory for Python < 3.10
-# TODO: Use `ignore_cleanup_errors=True` in Python 3.10+
-class TemporaryDirectoryIgnoreErrors(tempfile.TemporaryDirectory):  # noqa: D101
-    def cleanup(self) -> None:  # noqa: D102
-        with contextlib.suppress(Exception):
-            super().cleanup()  # Ignore cleanup errors
-
-
-TEMP_DIR: "TemporaryDirectoryIgnoreErrors | None" = None
-
-
-def setup_jupyter_data_dirs() -> "tuple[Path, list[Path]]":  # noqa: D103
-    global TEMP_DIR  # noqa: PLW0603
-
-    juv_data_dir = Path(user_data_dir("juv"))
-    juv_data_dir.mkdir(parents=True, exist_ok=True)
-
-    TEMP_DIR = TemporaryDirectoryIgnoreErrors(dir=juv_data_dir)
-    merged_data_dir = Path(TEMP_DIR.name)
-
-    def handle_termination(signum, frame) -> None:  # noqa: ANN001, ARG001
-        if TEMP_DIR:
-            TEMP_DIR.cleanup()
-        sys.exit(0)
-
-    signal.signal(signal.SIGTERM, handle_termination)
-    signal.signal(signal.SIGINT, handle_termination)
-
+def setup_jupyter_data_dirs() -> "tuple[list[Path], list[Path]]":  # noqa: D103
     config_paths: "list[Path]" = []  # noqa: UP037
     root_data_dir = Path(sys.prefix) / "share" / "jupyter"
     jupyter_paths = [root_data_dir]
@@ -48,18 +17,8 @@ def setup_jupyter_data_dirs() -> "tuple[Path, list[Path]]":  # noqa: D103
         data_dir = venv_path / "share" / "jupyter"
         if not data_dir.exists() or str(data_dir) == str(root_data_dir):
             continue
-
         jupyter_paths.append(data_dir)
-
-    for path in reversed(jupyter_paths):
-        for item in path.rglob("*"):
-            if item.is_file():
-                dest = merged_data_dir / item.relative_to(path)
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                with contextlib.suppress(FileExistsError):
-                    os.link(item, dest)
-
-    return merged_data_dir, config_paths
+    return jupyter_paths, config_paths
 
 
 def write_notebook_lockfile_contents_and_delete(  # noqa: D103
@@ -100,9 +59,9 @@ def setup(notebook: str, jupyter: str, run_mode: str) -> None:  # noqa: D103
         print(f"JUV_MANGED={jupyter},{version}", file=sys.stderr)  # noqa: T201
 
     # wire up juptyer dirs for this enviroment
-    data_dir, config_paths = setup_jupyter_data_dirs()
-    os.environ["JUPYTER_DATA_DIR"] = str(data_dir)
-    os.environ["JUPYTER_CONFIG_PATH"] = os.pathsep.join(map(str, config_paths))
+    jupyter_paths, jupyter_config_paths = setup_jupyter_data_dirs()
+    os.environ["JUPYTER_PATH"] = os.pathsep.join(map(str, jupyter_paths))
+    os.environ["JUPYTER_CONFIG_PATH"] = os.pathsep.join(map(str, jupyter_config_paths))
 
     # delete this temporary script
     with contextlib.suppress(PermissionError):


### PR DESCRIPTION
This PR simplifies how we set up Jupyter paths in `juv run` and _should_ hopefully fix (#61). 

Instead of creating a merged directory of Jupyter data files, we now just set `JUPYTER_PATH` and `JUPYTER_CONFIG_PATH` directly based on what's available in the current virtual environment. This works better across platforms and avoids the complexity of copying, linking, deleting files. 

I _think_ what is happening on Windows is that we weren’t correctly identifying the virtual environment root. Unix and Windows place `site-packages` at different depths, so the old logic would go up three levels regardless. Now we handle each case explicitly, which should make path resolution more reliable.

```sh
# Unix
<venv>/lib/pythonX.Y/site-packages/
<venv>/share/jupyter/
<venv>/etc/jupyter/

# Windows
<venv>/Lib/site-packages/
<venv>/share/jupyter/
<venv>/etc/jupyter/
```

I don't have a great way to test but would love if either @ATL2001 or @Jhsmit would give it a spin. I'm going to make a release either way, but would love to know if we can close #61.