### PR TITLE
Fix Ctrl+C handling on Windows subprocesses

### DIFF
--- a/src/juv/_run_managed.py
+++ b/src/juv/_run_managed.py
@@ -124,6 +124,8 @@ def run(
         encoding="utf-8",
     ) as f:
         script_path = Path(f.name)
+        atexit.register(lambda: script_path.unlink(missing_ok=True))
+
         lockfile = Path(f"{f.name}.lock")
         f.write(script)
         f.flush()
@@ -161,8 +163,5 @@ def run(
             lockfile.unlink(missing_ok=True)
             output_queue.put(None)
             output_thread.join()
-
-        # ensure the process is fully cleaned up before deleting script
-        process.wait()
-        # unlink after process has exited
-        atexit.register(lambda: script_path.unlink(missing_ok=True))
+            # ensure the process is fully cleaned up before deleting script
+            process.wait()


### PR DESCRIPTION
Ensures subprocesses receive `CTRL_BREAK_EVENT` on Windows by attaching
stdin and using send_signal instead of SIGTERM. Also register script
cleanup earlier to avoid leaving temp files behind if interrupted.
